### PR TITLE
Add policy for the Forgotten Ship ghost roles

### DIFF
--- a/policy.json
+++ b/policy.json
@@ -22,6 +22,8 @@
 	"Coroner":"More information on this job is available at: https://paradisestation.org/tgwiki2/index.php?title=Coroner",
 	"Curator":"More information on this job is available at: https://paradisestation.org/tgwiki2/index.php?title=Curator",
 	"Cyborg":"Be sure to familiarize yourself with silicon policy at: https://paradisestation.org/tgwiki2/index.php?title=Silicon_Policy and please contact an administrator if you need assistance interpreting your laws",
+	"Cybersun Space Syndicate Captain":"You are free to explore space and lethally fight any Nanotrasen crew you may meet, but you should <i>never</i> seek out the station to cause harm and destruction.",
+	"Cybersun Space Syndicate":"You are free to explore space and lethally fight any Nanotrasen crew you may meet, but you should <i>never</i> seek out the station to cause harm and destruction.",
 	"Detective":"Your revolver should only be used for self defense. More information on this job is available at: https://paradisestation.org/tgwiki2/index.php?title=Detective",
 	"Free Golem":"You should seek to build a home for your people upon the rocky soil below you, and should only briefly venture out beyond your homeland to trade or interact with others.",
 	"Geneticist":"Please see the Guide to Genetics at: https://paradisestation.org/tgwiki2/index.php?title=Guide_to_genetics",


### PR DESCRIPTION
Policy text:

> You are free to explore space and lethally fight any Nanotrasen crew you may meet, but you should <i>never</i> seek out the station to cause harm and destruction.