### PR TITLE
Modify round announcements to actually work (i hope)

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -419,7 +419,9 @@ MINUTE_CLICK_LIMIT 400
 ## Various messages to be sent to connected chat channels.
 ## Uncommenting these will enable them, by default they will be broadcast to Game chat channels on TGS3 or non-admin channels on TGS>=4.
 ## If using TGS>=4, the string option can be set as one of more chat channel tags (separated by ','s) to limit the message to channels with that tag name (case-sensitive). This will have no effect on TGS3.
-## i.e. CHANNEL_ANNOUNCE_NEW_GAME chat_channel_tag
+## You can also specify multiple channel tags by using the config option multiple times,
+## i.e. CHANNEL_ANNOUNCE_NEW_GAME chat_channel_tag_1
+## i.e. CHANNEL_ANNOUNCE_NEW_GAME chat_channel_tag_2
 
 ## Which channel will have a message about a new game starting, message includes the station name.
 CHANNEL_ANNOUNCE_NEW_GAME tg-general

--- a/manuel/config.txt
+++ b/manuel/config.txt
@@ -24,6 +24,8 @@ HUB
 ## The address shown for the game server in the TGS check command
 PUBLIC_ADDRESS manuel.tgstation13.org:1447
 
+## The channel announcement configs below do not override the values set in ../config.txt, see the original comment for further explanation
+
 ## Which channel will have a message about a new game starting, message includes the station name.
 CHANNEL_ANNOUNCE_NEW_GAME manuelcord-manuel-roundend
 

--- a/manuel/config.txt
+++ b/manuel/config.txt
@@ -25,13 +25,13 @@ HUB
 PUBLIC_ADDRESS manuel.tgstation13.org:1447
 
 ## Which channel will have a message about a new game starting, message includes the station name.
-CHANNEL_ANNOUNCE_NEW_GAME manuelcord-manuel-roundend,tg-general
+CHANNEL_ANNOUNCE_NEW_GAME manuelcord-manuel-roundend
 
 ## Which channel will have a message about a new game starting, message includes the round ID of the game that has just ended.
-CHANNEL_ANNOUNCE_END_GAME manuelcord-manuel-roundend,tg-general
+CHANNEL_ANNOUNCE_END_GAME manuelcord-manuel-roundend
 
 ## Ping users who use the `notify` command when a new game starts.
-CHAT_NEW_GAME_NOTIFICATIONS manuelcord-manuel-roundend,tg-general
+CHAT_NEW_GAME_NOTIFICATIONS manuelcord-manuel-roundend
 
 ## set a server location for world reboot. Don't include the byond://, just give the address and port.
 ## Don't set this to the same server, BYOND will automatically restart players to the server when it has restarted.


### PR DESCRIPTION
The channel announcement configs were changed to be string lists, so this should in theory post to `tg-general` and `manuelcord-manuel-roundend` now 