### PR TITLE
Implements https://github.com/tgstation/tgstation/pull/89522 (changes to auto deadmin config)

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -359,7 +359,10 @@ AUTOADMIN_RANK Game Master
 #AUTOADMIN
 
 ## Uncomment to automatically deadmin players when the game starts.
-AUTO_DEADMIN_PLAYERS
+#AUTO_DEADMIN_PLAYERS
+
+## Uncomment to automatically deadmin players when they click to ready up or join game. For latejoining, does it before they pick a role because it's best done early to limit metainfo.
+AUTO_DEADMIN_ON_READY_OR_LATEJOIN
 
 ## Uncomment to automatically deadmin antagonists when they gain the role.
 #AUTO_DEADMIN_ANTAGONISTS


### PR DESCRIPTION
Disables the config flag that auto deadminned any admin any time they entered any mob at all ever, everywhere, all at once.
Enables the new config flag added by https://github.com/tgstation/tgstation/pull/89522 that auto deadmins admins on ready up or latejoin.