### PR TITLE
Set public configs for urgent ahelps

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -520,7 +520,7 @@ DRIFT_PROFILE_DELAY 150
 URGENT_AHELP_COOLDOWN 300
 
 ## The message that is sent to the discord if an urgent ahelp is sent. Useful for sending a role ping.
-#URGENT_AHELP_MESSAGE
+URGENT_AHELP_MESSAGE <@&492378866736693248>
 
 ## See above, but for non-urgent ahelps.
 #AHELP_MESSAGE

--- a/manuel/config.txt
+++ b/manuel/config.txt
@@ -35,6 +35,12 @@ CHANNEL_ANNOUNCE_END_GAME manuelcord-manuel-roundend
 ## Ping users who use the `notify` command when a new game starts.
 CHAT_NEW_GAME_NOTIFICATIONS manuelcord-manuel-roundend
 
+## The URL for the pfp of the webhook
+ADMINHELP_WEBHOOK_PFP https://cdn.discordapp.com/avatars/1331173647871643700/f52cf18829d1147c982b0f6980f0e915.webp
+
+## The name of the webhook
+ADMINHELP_WEBHOOK_NAME Sir Manuel
+
 ## set a server location for world reboot. Don't include the byond://, just give the address and port.
 ## Don't set this to the same server, BYOND will automatically restart players to the server when it has restarted.
 ## This is also used to show the server's address in the TGS check command if the public address isn't set

--- a/sybil/config.txt
+++ b/sybil/config.txt
@@ -29,6 +29,12 @@ HUB
 ## The address shown for the game server in the TGS check command
 PUBLIC_ADDRESS sybil.tgstation13.org:1337
 
+## The URL for the pfp of the webhook
+ADMINHELP_WEBHOOK_PFP https://cdn.discordapp.com/avatars/1331176361234268201/fecef27496b0b9c467f2f357f70aab97.webp
+
+## The name of the webhook
+ADMINHELP_WEBHOOK_NAME Madame Sybil
+
 ## Sets an MOTD of the server.
 ## You can use this multiple times, and the MOTDs will be appended in order.
 ## Based on config directory, so "motd.txt" points to "config/motd.txt"

--- a/terry/config.txt
+++ b/terry/config.txt
@@ -24,6 +24,12 @@ HUB
 ## The address shown for the game server in the TGS check command
 PUBLIC_ADDRESS terry.tgstation13.org:3336
 
+## The URL for the pfp of the webhook
+ADMINHELP_WEBHOOK_PFP https://cdn.discordapp.com/avatars/1331177853286617089/31399227a69606212a79feec28fd2777.webp
+
+## The name of the webhook
+ADMINHELP_WEBHOOK_NAME Lord Terry
+
 ## set a server location for world reboot. Don't include the byond://, just give the address and port.
 ## Don't set this to the same server, BYOND will automatically restart players to the server when it has restarted.
 ## This is also used to show the server's address in the TGS check command if the public address isn't set


### PR DESCRIPTION
Still relies on URGENT_ADMINHELP_WEBHOOK_URL but that should be set in secrets