### PR TITLE
Delta Station is not voteable in lowpop

### DIFF
--- a/maps.txt
+++ b/maps.txt
@@ -24,7 +24,7 @@ map birdshot
 endmap
 
 map deltastation
-	#minplayers 50
+	minplayers 50
 	votable
 endmap
 


### PR DESCRIPTION
I was told in #map-surveying that this might be unintended, so here is a PR to fix it. In my IMO it is very unfun to get Delta in lowpop, and it does happen due to how the modern mapvote system works. These numbers in general are worth reviewing as well, open to suggestions. 