### PR TITLE
Modify urgent ahelp user prompt

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -528,7 +528,7 @@ URGENT_AHELP_MESSAGE <@&492378866736693248>
 #AHELP_MESSAGE
 
 ## The message that the player receives whenever prompted whether they want to send an urgent ahelp or not.
-#URGENT_AHELP_USER_PROMPT This'll ping the admins!
+URGENT_AHELP_USER_PROMPT There are no admins currently on. The button below will notify admins on our Discord server about your ahelp. Do not press the button below if your ahelp is a joke, a request or a question.
 
 ## The link that the title of a ticket can link to.
 ## If not set, it will link nowhere


### PR DESCRIPTION
https://forums.tgstation13.org/viewtopic.php?t=38518

Overrides the codebase's default text from
> There are no admins currently on. Do not press the button below if your ahelp is a joke, a request or a question. Use it only for cases of obvious grief.

to

> There are no admins currently on. The button below will notify admins on our Discord server about your ahelp. Do not press the button below if your ahelp is a joke, a request or a question.