### PR TITLE
Make space ruins less likely.

### DIFF
--- a/game_options.txt
+++ b/game_options.txt
@@ -411,7 +411,7 @@ BOMBCAP 32
 LAVALAND_BUDGET 60
 
 ## Space Ruin Budget
-SPACE_BUDGET 64
+SPACE_BUDGET 30
 
 ## Time in ds from when a player latejoins till the arrival shuttle docks at the station
 ## Must be at least 30. At least 55 recommended to be visually/aurally appropriate


### PR DESCRIPTION
Previous value of 64 generated ~30 space ruins. I went on a server to see what was gwan, increased my view distance to 34 and had like 6 ruins in view range on one z-level.

Could probably do with less.

https://forums.tgstation13.org/viewtopic.php?p=776340