### PR TITLE
Use a different config method to limit assistant slots.

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -229,7 +229,7 @@ REQUEST_INTERNET_ALLOWED youtube\.com\/watch?v=,youtu\.be\/,soundcloud\.com\/,ba
 ## Playtime Requirements is in minutes, Required Account Age is in days.
 ## Human Authority Whitelist Setting can either be 0 or 1.
 ## Make sure to read the start of the file to get a more in-depth explanation of what each entry does!
-LOAD_JOBS_FROM_TXT
+#LOAD_JOBS_FROM_TXT
 
 ## Uncomment this to forbid admins from possessing the singularity.
 ## It is intentional that Admins can edit this config, as its meant to serve as a deterrent/warning for admin abuse.

--- a/manuel/config.txt
+++ b/manuel/config.txt
@@ -3,6 +3,7 @@
 $include resources.txt
 $include comms.txt
 $include dbconfig.txt
+$include game_options.txt
 
 # You can use the @ character at the beginning of a config option to lock it from being edited in-game
 # Example usage:

--- a/manuel/game_options.txt
+++ b/manuel/game_options.txt
@@ -1,0 +1,2 @@
+## Overflow slot cap. Set to -1 for unlimited. If limited, it will still open up if every other job is full.
+OVERFLOW_CAP 5

--- a/manuel/jobconfig.toml
+++ b/manuel/jobconfig.toml
@@ -30,8 +30,8 @@
 "# Playtime Requirements" = 0
 "# Required Account Age" = 0
 "# Required Character Age" = 0
-"Spawn Positions" = 5
-"Total Positions" = 5
+"# Spawn Positions" = -1
+"# Total Positions" = -1
 
 [ATMOSPHERIC_TECHNICIAN]
 "# Playtime Requirements" = 60


### PR DESCRIPTION
Limits assistant slots via a server-specific game_options.txt override.

This config is probably more suited to the task than jobconfig.toml because it'll make assistant slots unlimited again if all other job slots are filled (unless the config is lying).