### PR TITLE
Tweaks to Terry dynamic setup

### DIFF
--- a/terry/dynamic.json
+++ b/terry/dynamic.json
@@ -1,5 +1,16 @@
 {
-	"Dynamic": {},
+	"Dynamic": {
+		/* iain0 - some narrative on what I'm hoping to achieve */
+		/* Move the mid point / average threat up from 50 to probably 55ish - default is 0, range -5 to 5, so this is a 5% shift*/
+		"threat_curve_centre" = 0.5,
+		/* Tighten up the threat curve pulling more rounds into the middle area and less on the tails - notably with the shift above this reduces greenshifts more than black orbits */
+		/* Hopefully this provides a little more consistency between rounds and less dramatically swinging between extremes - default is 1.8 */
+		"threat_curve_width" = 1.5,
+		/* Similarly tighten up the round start split curve a little so we have less rounds where everything is dumped into round start or entirely midrounds - default 1.8 */
+		"roundstart_split_curve_width" = 1.5
+		/* for future note, midround_upper_bound is interesting and defines when all threat will have been spent by, however having already reduced costs lets see how this goes */
+	        /* before making things more frequent effectively.  also I have no idea how you'd set that kind of config var */
+	},
 	"Roundstart": {
 		"Traitors": {
 			"cost": 8,

--- a/terry/dynamic.json
+++ b/terry/dynamic.json
@@ -8,8 +8,7 @@
 		"threat_curve_width": 1.5,
 		/* Similarly tighten up the round start split curve a little so we have less rounds where everything is dumped into round start or entirely midrounds - default 1.8 */
 		"roundstart_split_curve_width": 1.5
-		/* for future note, midround_upper_bound is interesting and defines when all threat will have been spent by, however having already reduced costs lets see how this goes */
-	        /* before making things more frequent effectively.  also I have no idea how you'd set that kind of config var */
+		/* for future note, midround_upper_bound is interesting and defines a target to spend all threat */
 	},
 	"Roundstart": {
 		"Traitors": {

--- a/terry/dynamic.json
+++ b/terry/dynamic.json
@@ -2,9 +2,9 @@
 	"Dynamic": {},
 	"Roundstart": {
 		"Traitors": {
-			"cost": 10,
+			"cost": 8,
 			"minimum_players": 10,
-			"scaling_cost": 10,
+			"scaling_cost": 8,
 			"requirements": [
 				101,
 				50,
@@ -19,7 +19,7 @@
 			]
 		},
 		"Blood Brothers": {	
-			"cost": 10,
+			"cost": 8,
 			"minimum_players": 10,
 			"requirements": [
 				101,
@@ -65,8 +65,8 @@
 			]
 		},
 		"Changelings": {
-			"cost": 15,
-			"scaling_cost": 15,
+			"cost": 12,
+			"scaling_cost": 12,
 			"minimum_players": 10,
 			"requirements": [
 				101,
@@ -82,8 +82,8 @@
 			]
 		},
 		"Heretics": {
-			"cost": 15,
-			"scaling_cost": 10,
+			"cost": 12,
+			"scaling_cost": 8,
 			"minimum_players": 10,
 			"requirements": [
 				101,
@@ -118,7 +118,7 @@
 			]
 		},
 		"Spies": {
-			"cost": 10,
+			"cost": 7,
 			"scaling_cost": 5,
 			"requirements": [
 				101,
@@ -158,7 +158,7 @@
 			"cost": 20
 		},
 		"Space Ninja": {
-			"cost": 10
+			"cost": 7
 		},
 		"Nightmare": {
 			"cost": 5
@@ -177,7 +177,7 @@
 			"minimum_players": 10
 		},
 		"Paradox Clone": {
-			"cost": 5
+			"cost": 3
 		},
 		"Space Pirates": {
 			"cost": 5

--- a/terry/dynamic.json
+++ b/terry/dynamic.json
@@ -1,14 +1,8 @@
 {
 	"Dynamic": {
-		/* iain0 - some narrative on what I'm hoping to achieve */
-		/* Move the mid point / average threat up from 50 to probably 55ish - default is 0, range -5 to 5, so this is a 5% shift*/
 		"threat_curve_centre": 0.5,
-		/* Tighten up the threat curve pulling more rounds into the middle area and less on the tails - notably with the shift above this reduces greenshifts more than black orbits */
-		/* Hopefully this provides a little more consistency between rounds and less dramatically swinging between extremes - default is 1.8 */
 		"threat_curve_width": 1.5,
-		/* Similarly tighten up the round start split curve a little so we have less rounds where everything is dumped into round start or entirely midrounds - default 1.8 */
 		"roundstart_split_curve_width": 1.5
-		/* for future note, midround_upper_bound is interesting and defines a target to spend all threat */
 	},
 	"Roundstart": {
 		"Traitors": {

--- a/terry/dynamic.json
+++ b/terry/dynamic.json
@@ -2,12 +2,12 @@
 	"Dynamic": {
 		/* iain0 - some narrative on what I'm hoping to achieve */
 		/* Move the mid point / average threat up from 50 to probably 55ish - default is 0, range -5 to 5, so this is a 5% shift*/
-		"threat_curve_centre" = 0.5,
+		"threat_curve_centre": 0.5,
 		/* Tighten up the threat curve pulling more rounds into the middle area and less on the tails - notably with the shift above this reduces greenshifts more than black orbits */
 		/* Hopefully this provides a little more consistency between rounds and less dramatically swinging between extremes - default is 1.8 */
-		"threat_curve_width" = 1.5,
+		"threat_curve_width": 1.5,
 		/* Similarly tighten up the round start split curve a little so we have less rounds where everything is dumped into round start or entirely midrounds - default 1.8 */
-		"roundstart_split_curve_width" = 1.5
+		"roundstart_split_curve_width": 1.5
 		/* for future note, midround_upper_bound is interesting and defines when all threat will have been spent by, however having already reduced costs lets see how this goes */
 	        /* before making things more frequent effectively.  also I have no idea how you'd set that kind of config var */
 	},


### PR DESCRIPTION
Some dynamic tweaks for Terry:

* Move threat curve center up, raising average threat from 50 to 55ish.
* Slightly tighten the threat curve resulting in more rounds closer to 55 than spread out at extremes.
* Slightly tighten the round start split to make it less likely to spend all threat at round start or mid round.

Threat cost changes:
Round start (from -> to)
* Traitors 10->8 per
* Blood brothers 10-8 per
* Changeling 15->12 per
* Heretics 15->12 +(10->8) per additional
* Spies 10->8 +5 per additional

Midround
* Ninja 10->7
* Paradox Clone 5->3
