### PR TITLE
Raise radiation storm event to 15 pop

### DIFF
--- a/events.json
+++ b/events.json
@@ -8,6 +8,9 @@
     "Grey Tide": {
         "min_players": 15
     },
+    "Radiation Storm": {
+        "min_players": 15
+    },    
     "Supermatter Surge": {
         "min_players": 15
     }


### PR DESCRIPTION
Because who opens maints, not to mention how many go AFK for a long time on lower pop.