### PR TITLE
Set terry threat curve to w4 @ c1, and split to w3 (@c1, default)

### DIFF
--- a/terry/dynamic.json
+++ b/terry/dynamic.json
@@ -1,8 +1,8 @@
 {
 	"Dynamic": {
-		"threat_curve_centre": 0.5,
-		"threat_curve_width": 1.5,
-		"roundstart_split_curve_width": 1.5
+		"threat_curve_centre": 1,
+		"threat_curve_width": 4,
+		"roundstart_split_curve_width": 3
 	},
 	"Roundstart": {
 		"Traitors": {


### PR DESCRIPTION
This configuration changes (for terry):
- Threat budget curve center to 1.0
- Threat budget curve width to 4.0
- Threat split curve width to 3.0

What does any of this mean? (if TLDR, the LAST GRAPH is the one we're proposing)

Here is Terry's threat curve from Jan/Feb post server wipe until I started tinkering a few weeks ago ; this is the codebase default threat curve (center 0, width 1.8):
![threat-c0-w1 8](https://github.com/user-attachments/assets/1257da52-8cfb-4215-a277-cd5b5863ff15)

This is remarkably flat and is, in most rounds, comparable to a random 1d100 die roll ; it has no really  noticable preference, mid threat rounds turn up slightly more often but overall it will be "all over the place", and anecdotally this is how it felt as an admin back then.

The proposed previous change was to raise the threat slightly and "bunch it up" to make it more consistent, however, the documentation for dynamic is wrong and describes the width incorrectly ; smaller values make things MORE extreme not less, so the previous change was to (center 0.5, width 1.5) HOWEVER the lower width ended up making extremes a little more likely (at both ends, high and low threat):
![threat-c0 5-w1 5](https://github.com/user-attachments/assets/f6461bc2-8c91-4083-a478-817caf0db45e)

Now that I have a whole table of threat graphs I can just pick visually, the choices here of (center 1.0, width 4.0) result in this graph, and this forms the proposal for this change.
![threat-c1-w4](https://github.com/user-attachments/assets/aa80eec8-2bde-4a3f-b876-bf3664a9fab4)

The round start split of 100 threat would follow a similar but slightly shallower curve.