### PR TITLE
Effective restoration of dynamic config from pre server wipes

### DIFF
--- a/manuel/dynamic.json
+++ b/manuel/dynamic.json
@@ -1,5 +1,8 @@
 {
-	"Dynamic": {},
+	"Dynamic": {
+		"threat_curve_centre": -0.4,
+		"threat_curve_width": 4
+	},
 	"Roundstart": {
 		"Traitors": {
 			"cost": 10,


### PR DESCRIPTION
This PR changes Manuel's dynamic curve to
- Threat budget center at -0.4 (from 0)
- Threat budget width at 4 (from 1.8)

These should be the settings that Manuel had before the server wipe in Jan where the config was reset, for visualisation, here is the **CURRENT** graph manuel is using (center 0 width 1.8, codebase defaults) where round threat is for most rounds an entirely random number with no distribution bias.
![threat-c0-w1 8](https://github.com/user-attachments/assets/15f4425a-d06f-4415-be7f-45012b086d69)

The proposed (restored) changes will move the graph to (center -0.4, width 4) which produce the following:
![threat-c-0 4-w4](https://github.com/user-attachments/assets/f7eb6f9f-5207-4737-92d6-eab006ff18ff)
