### PR TITLE
For manuel, configure ROUNDSTART_BLUE_ALERT to 0

### DIFF
--- a/manuel/config.txt
+++ b/manuel/config.txt
@@ -67,3 +67,8 @@ EXTREME_POPCAP_MESSAGE The server is currently serving a high number of users, b
 
 ## Uncomment to allow BYOND subscribers to bypassing server connection population cap. (Living player population cap still applies.)
 BYOND_MEMBER_BYPASS_POPCAP
+
+## If TRUE / 1, station is raised to blue alert at roundstart.
+## If FALSE / 0, station remains at green alert.
+## Roundstart command report and greendshift announcements are unaffected.
+ROUNDSTART_BLUE_ALERT 0


### PR DESCRIPTION
On manuel only, disable the automatic elevation of the security level to blue alert at/near round start.  This must now be enacted by a suitable in-game step.
