### PR TITLE
Terry Dynamic - Tiered Approach

### DIFF
--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -2,23 +2,23 @@
 weight = 0
 
 ["Low Chaos"]
-name = "Low Chaos"
+name = "Yellow Star"
 min_pop = 0
-weight = 10
+weight = 20
 advisory_report = "Advisory Level: <b>Yellow Star</b></center><BR>Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
 ruleset_type_settings.roundstart.low = 1
-ruleset_type_settings.roundstart.high = 1
+ruleset_type_settings.roundstart.high = 2
 ruleset_type_settings.roundstart.half_range_pop_threshold = 25
 ruleset_type_settings.roundstart.full_range_pop_threshold = 40
-ruleset_type_settings.light_midround.low = 0
+ruleset_type_settings.light_midround.low = 1
 ruleset_type_settings.light_midround.high = 2
 ruleset_type_settings.light_midround.half_range_pop_threshold = 25
 ruleset_type_settings.light_midround.full_range_pop_threshold = 40
 ruleset_type_settings.light_midround.time_threshold = 25
-ruleset_type_settings.light_midround.execution_cooldown_low = 10
-ruleset_type_settings.light_midround.execution_cooldown_high = 20
+ruleset_type_settings.light_midround.execution_cooldown_low = 15
+ruleset_type_settings.light_midround.execution_cooldown_high = 25
 ruleset_type_settings.heavy_midround.low = 0
-ruleset_type_settings.heavy_midround.high = 1
+ruleset_type_settings.heavy_midround.high = 0
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 25
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 40
 ruleset_type_settings.heavy_midround.time_threshold = 50
@@ -28,57 +28,57 @@ ruleset_type_settings.latejoin.low = 0
 ruleset_type_settings.latejoin.high = 1
 ruleset_type_settings.latejoin.half_range_pop_threshold = 25
 ruleset_type_settings.latejoin.full_range_pop_threshold = 40
-ruleset_type_settings.latejoin.time_threshold = 5
-ruleset_type_settings.latejoin.execution_cooldown_low = 10
-ruleset_type_settings.latejoin.execution_cooldown_high = 20
+ruleset_type_settings.latejoin.time_threshold = 15
+ruleset_type_settings.latejoin.execution_cooldown_low = 15
+ruleset_type_settings.latejoin.execution_cooldown_high = 30
 
 ["Low-Medium Chaos"]
-name = "Low-Medium Chaos"
+name = "Orange Star"
 min_pop = 0
-weight = 20
-advisory_report = "Advisory Level: <b>Red Star</b></center><BR>Your sector's advisory level is Red Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
+weight = 45
+advisory_report = "Advisory Level: <b>Orange Star</b></center><BR>Your sector's advisory level is Orange Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
 ruleset_type_settings.roundstart.low = 1
-ruleset_type_settings.roundstart.high = 2
+ruleset_type_settings.roundstart.high = 3
 ruleset_type_settings.roundstart.half_range_pop_threshold = 25
 ruleset_type_settings.roundstart.full_range_pop_threshold = 40
-ruleset_type_settings.light_midround.low = 0
-ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.light_midround.low = 2
+ruleset_type_settings.light_midround.high = 3
 ruleset_type_settings.light_midround.half_range_pop_threshold = 25
 ruleset_type_settings.light_midround.full_range_pop_threshold = 40
-ruleset_type_settings.light_midround.time_threshold = 20
+ruleset_type_settings.light_midround.time_threshold = 25
 ruleset_type_settings.light_midround.execution_cooldown_low = 10
-ruleset_type_settings.light_midround.execution_cooldown_high = 20
-ruleset_type_settings.heavy_midround.low = 0
-ruleset_type_settings.heavy_midround.high = 1
+ruleset_type_settings.light_midround.execution_cooldown_high = 15
+ruleset_type_settings.heavy_midround.low = 1
+ruleset_type_settings.heavy_midround.high = 2
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 25
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 40
 ruleset_type_settings.heavy_midround.time_threshold = 45
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
-ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 1
+ruleset_type_settings.heavy_midround.execution_cooldown_high = 30
+ruleset_type_settings.latejoin.low = 0
 ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 25
 ruleset_type_settings.latejoin.full_range_pop_threshold = 40
-ruleset_type_settings.latejoin.time_threshold = 5
+ruleset_type_settings.latejoin.time_threshold = 10
 ruleset_type_settings.latejoin.execution_cooldown_low = 10
 ruleset_type_settings.latejoin.execution_cooldown_high = 20
 
 ["Medium-High Chaos"]
-name = "Medium-High Chaos"
+name = "Red Star"
 min_pop = 0
-weight = 50
-advisory_report = "Advisory Level: <b>Black Orbit</b></center><BR>Your sector's advisory level is Black Orbit. Your sector's local communications network is currently undergoing a blackout, and we are therefore unable to accurately judge enemy movements within the region. However, information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of an impending attack. Remain on high alert and vigilant against any other potential threats."
+weight = 25
+advisory_report = "Advisory Level: <b>Red Star</b></center><BR>Your sector's advisory level is Red Star. Multiple communications signals in your sector have been intercepted, with partial success in decryption. Analysis combined with information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of impending attacks. Remain on high alert and vigilant against any potential threats."
 ruleset_type_settings.roundstart.low = 2
 ruleset_type_settings.roundstart.high = 3
 ruleset_type_settings.roundstart.half_range_pop_threshold = 25
 ruleset_type_settings.roundstart.full_range_pop_threshold = 40
-ruleset_type_settings.light_midround.low = 1
-ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.light_midround.low = 2
+ruleset_type_settings.light_midround.high = 3
 ruleset_type_settings.light_midround.half_range_pop_threshold = 25
 ruleset_type_settings.light_midround.full_range_pop_threshold = 40
 ruleset_type_settings.light_midround.time_threshold = 20
 ruleset_type_settings.light_midround.execution_cooldown_low = 10
-ruleset_type_settings.light_midround.execution_cooldown_high = 20
+ruleset_type_settings.light_midround.execution_cooldown_high = 15
 ruleset_type_settings.heavy_midround.low = 1
 ruleset_type_settings.heavy_midround.high = 2
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 25
@@ -86,30 +86,30 @@ ruleset_type_settings.heavy_midround.full_range_pop_threshold = 40
 ruleset_type_settings.heavy_midround.time_threshold = 40
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 1
-ruleset_type_settings.latejoin.high = 3
+ruleset_type_settings.latejoin.low = 0
+ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 25
 ruleset_type_settings.latejoin.full_range_pop_threshold = 40
 ruleset_type_settings.latejoin.time_threshold = 5
-ruleset_type_settings.latejoin.execution_cooldown_low = 10
-ruleset_type_settings.latejoin.execution_cooldown_high = 20
+ruleset_type_settings.latejoin.execution_cooldown_low = 5
+ruleset_type_settings.latejoin.execution_cooldown_high = 15
 
 ["High Chaos"]
-name = "High Chaos"
+name = "Black Orbit"
 min_pop = 25
-weight = 20
-advisory_report = "Advisory Level: <b>Midnight Sun</b></center><BR>Your sector's advisory level is Midnight Sun. Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
-ruleset_type_settings.roundstart.low = 3
-ruleset_type_settings.roundstart.high = 4
+weight = 10
+advisory_report = "Advisory Level: <b>Black Orbit</b></center><BR>Your sector's advisory level is Black Orbit. Multiple jamming signals in your region limit intelligence and render traditional classifications inapplicable.  Analysis suggests a mask to cover a large scale mobilisation in the region, or multiple significant independent threats.  Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
+ruleset_type_settings.roundstart.low = 2
+ruleset_type_settings.roundstart.high = 2
 ruleset_type_settings.roundstart.half_range_pop_threshold = 25
 ruleset_type_settings.roundstart.full_range_pop_threshold = 40
-ruleset_type_settings.light_midround.low = 1
-ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.light_midround.low = 3
+ruleset_type_settings.light_midround.high = 5
 ruleset_type_settings.light_midround.half_range_pop_threshold = 25
 ruleset_type_settings.light_midround.full_range_pop_threshold = 40
-ruleset_type_settings.light_midround.time_threshold = 20
-ruleset_type_settings.light_midround.execution_cooldown_low = 10
-ruleset_type_settings.light_midround.execution_cooldown_high = 20
+ruleset_type_settings.light_midround.time_threshold = 15
+ruleset_type_settings.light_midround.execution_cooldown_low = 7
+ruleset_type_settings.light_midround.execution_cooldown_high = 13
 ruleset_type_settings.heavy_midround.low = 2
 ruleset_type_settings.heavy_midround.high = 4
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 25
@@ -117,469 +117,268 @@ ruleset_type_settings.heavy_midround.full_range_pop_threshold = 40
 ruleset_type_settings.heavy_midround.time_threshold = 30
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 2
-ruleset_type_settings.latejoin.high = 3
+ruleset_type_settings.latejoin.low = 1
+ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 25
 ruleset_type_settings.latejoin.full_range_pop_threshold = 40
 ruleset_type_settings.latejoin.time_threshold = 5
-ruleset_type_settings.latejoin.execution_cooldown_low = 10
-ruleset_type_settings.latejoin.execution_cooldown_high = 20
+ruleset_type_settings.latejoin.execution_cooldown_low = 5
+ruleset_type_settings.latejoin.execution_cooldown_high = 10
 
 
 ["Latejoin Traitor"]
 weight = 10
 min_pop = 3
-blacklisted_roles = [
-	"Head of Personnel",
-]
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Latejoin Heretic"]
-weight = 3
+weight.1 = 0
+weight.2 = 3
+weight.3 = 5
+weight.4 = 10
 min_pop = 30
-blacklisted_roles = [
-	"Head of Personnel",
-]
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Latejoin Changeling"]
-weight = 3
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
 min_pop = 15
-blacklisted_roles = [
-	"Head of Personnel",
-]
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Latejoin Revolution"]
-weight = 1
-min_pop = 30
-blacklisted_roles = []
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
-
-["Spiders"]
 weight.1 = 0
 weight.2 = 0
 weight.3 = 1
 weight.4 = 2
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 0
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
+
+["Spiders"]
+weight.1 = 0
+weight.2 = 10
+weight.3 = 10
+weight.4 = 10
+min_pop = 30
 
 ["Light Pirates"]
-weight = 3
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
 min_pop = 15
-blacklisted_roles = []
-min_antag_cap = 0
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Heavy Pirates"]
-weight = 3
+weight.1 = 0
+weight.2 = 10
+weight.3 = 10
+weight.4 = 10
 min_pop = 25
-blacklisted_roles = []
-min_antag_cap = 0
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Midround Wizard"]
 weight.1 = 0
 weight.2 = 0
 weight.3 = 1
-weight.4 = 2
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Midround Nukeops"]
 weight.1 = 0
 weight.2 = 1
-weight.3 = 3
-weight.4 = 3
+weight.3 = 2
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap.denominator = 18
-min_antag_cap.offset = 1
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Midround Clownops"]
 weight = 0
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap.denominator = 18
-min_antag_cap.offset = 1
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Blob"]
 weight.1 = 0
 weight.2 = 1
-weight.3 = 3
-weight.4 = 3
+weight.3 = 2
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 3
-repeatable = 1
-minimum_required_age = 0
 
 ["Xenomorph"]
 weight.1 = 0
-weight.2 = 1
-weight.3 = 5
-weight.4 = 5
+weight.2 = 10
+weight.3 = 10
+weight.4 = 10
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 2
-repeatable_weight_decrease = 3
-repeatable = 1
-minimum_required_age = 0
 
 ["Nightmare"]
-weight = 5
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
 min_pop = 15
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Space Dragon"]
 weight.1 = 0
-weight.2 = 3
-weight.3 = 5
-weight.4 = 5
+weight.2 = 5
+weight.3 = 10
+weight.4 = 10
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 3
-repeatable = 1
-minimum_required_age = 0
 
 ["Abductors"]
-weight = 5
+weight.1 = 5
+weight.2 = 3
+weight.3 = 3
+weight.4 = 1
 min_pop = 20
-blacklisted_roles = []
-min_antag_cap = 2
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 3
-repeatable = 1
-minimum_required_age = 0
 
 ["Space Ninja"]
 weight.1 = 0
-weight.2 = 0
-weight.3 = 1
-weight.4 = 2
+weight.2 = 5
+weight.3 = 10
+weight.4 = 10
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Revenant"]
-weight = 5
+weight.1 = 5
+weight.2 = 3
+weight.3 = 3
+weight.4 = 1
 min_pop = 10
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Midround Changeling"]
-weight = 5
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.10 = 10
 min_pop = 15
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Paradox Clone"]
-weight = 5
+weight.1 = 5
+weight.2 = 3
+weight.3 = 1
+weight.4 = 0
 min_pop = 10
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Voidwalker"]
-weight = 5
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Fugitives"]
-weight = 3
+weight.1 = 3
+weight.2 = 3
+weight.3 = 1
+weight.4 = 0
 min_pop = 20
-blacklisted_roles = []
-min_antag_cap = 3
-max_antag_cap = 4
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Morph"]
 weight = 0
 min_pop = 0
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Slaughter Demon"]
 weight = 0
 min_pop = 20
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Midround Traitor"]
 weight = 10
 min_pop = 3
-blacklisted_roles = [
-	"Head of Personnel",
-]
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Midround Malfunctioning AI"]
 weight.1 = 0
-weight.2 = 1
-weight.3 = 3
-weight.4 = 3
+weight.2 = 2
+weight.3 = 5
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Blob Infection"]
 weight.1 = 0
 weight.2 = 1
-weight.3 = 3
-weight.4 = 3
+weight.3 = 2
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-repeatable_weight_decrease = 3
-repeatable = 1
-minimum_required_age = 0
 
 ["Midround Obsessed"]
 weight.1 = 5
-weight.2 = 5
-weight.3 = 3
-weight.4 = 1
+weight.2 = 3
+weight.3 = 1
+weight.4 = 0
 min_pop = 5
-blacklisted_roles = []
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Roundstart Traitor"]
 weight = 10
 min_pop = 3
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap.denominator = 38
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Roundstart Malfunctioning AI"]
 weight.1 = 0
-weight.2 = 1
+weight.2 = 0
 weight.3 = 3
-weight.4 = 3
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Roundstart Blood Brothers"]
-weight = 5
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
 min_pop = 10
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap.denominator = 29
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Roundstart Changeling"]
-weight = 3
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
 min_pop = 15
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap.denominator = 29
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Roundstart Heretics"]
-weight = 3
+weight.1 = 0
+weight.2 = 3
+weight.3 = 5
+weight.4 = 10
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap.denominator = 24
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Roundstart Wizard"]
 weight.1 = 0
 weight.2 = 0
-weight.3 = 1
-weight.4 = 2
+weight.3 = 3
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 1
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Roundstart Blood Cult"]
 weight.1 = 0
-weight.2 = 1
+weight.2 = 0
 weight.3 = 3
-weight.4 = 3
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = [
-	"Head of Personnel",
-]
-min_antag_cap.denominator = 20
-min_antag_cap.offset = 1
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Roundstart Nukeops"]
 weight.1 = 0
-weight.2 = 1
+weight.2 = 0
 weight.3 = 3
-weight.4 = 3
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap.denominator = 18
-min_antag_cap.offset = 1
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Roundstart Clownops"]
 weight = 0
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap.denominator = 18
-min_antag_cap.offset = 1
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Roundstart Revolution"]
 weight.1 = 0
-weight.2 = 1
+weight.2 = 0
 weight.3 = 3
-weight.4 = 3
+weight.4 = 5
 min_pop = 30
-blacklisted_roles = []
-min_antag_cap = 1
-max_antag_cap = 3
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Roundstart Spies"]
-weight.1 = 0
-weight.2 = 1
-weight.3 = 3
-weight.4 = 3
+weight.1 = 10
+weight.2 = 5
+weight.3 = 5
+weight.4 = 5
 min_pop = 10
-blacklisted_roles = []
-min_antag_cap.denominator = 20
-min_antag_cap.offset = 1
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 1
-minimum_required_age = 0
 
 ["Extended"]
 weight = 0
 min_pop = 0
-blacklisted_roles = []
-min_antag_cap = 0
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Meteor"]
 weight = 0
 min_pop = 0
-blacklisted_roles = []
-min_antag_cap = 0
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0
 
 ["Nations"]
 weight = 0
 min_pop = 0
-blacklisted_roles = []
-min_antag_cap = 0
-# max_antag_cap = min_antag_cap
-repeatable_weight_decrease = 2
-repeatable = 0
-minimum_required_age = 0

--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -124,3 +124,462 @@ ruleset_type_settings.latejoin.full_range_pop_threshold = 40
 ruleset_type_settings.latejoin.time_threshold = 5
 ruleset_type_settings.latejoin.execution_cooldown_low = 10
 ruleset_type_settings.latejoin.execution_cooldown_high = 20
+
+
+["Latejoin Traitor"]
+weight = 10
+min_pop = 3
+blacklisted_roles = [
+	"Head of Personnel",
+]
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Latejoin Heretic"]
+weight = 3
+min_pop = 30
+blacklisted_roles = [
+	"Head of Personnel",
+]
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Latejoin Changeling"]
+weight = 3
+min_pop = 15
+blacklisted_roles = [
+	"Head of Personnel",
+]
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Latejoin Revolution"]
+weight = 1
+min_pop = 30
+blacklisted_roles = []
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Spiders"]
+weight.1 = 0
+weight.2 = 0
+weight.3 = 1
+weight.4 = 2
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 0
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Light Pirates"]
+weight = 3
+min_pop = 15
+blacklisted_roles = []
+min_antag_cap = 0
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Heavy Pirates"]
+weight = 3
+min_pop = 25
+blacklisted_roles = []
+min_antag_cap = 0
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Midround Wizard"]
+weight.1 = 0
+weight.2 = 0
+weight.3 = 1
+weight.4 = 2
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Midround Nukeops"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap.denominator = 18
+min_antag_cap.offset = 1
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Midround Clownops"]
+weight = 0
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap.denominator = 18
+min_antag_cap.offset = 1
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Blob"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 3
+repeatable = 1
+minimum_required_age = 0
+
+["Xenomorph"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 2
+repeatable_weight_decrease = 3
+repeatable = 1
+minimum_required_age = 0
+
+["Nightmare"]
+weight = 5
+min_pop = 15
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Space Dragon"]
+weight.1 = 0
+weight.2 = 3
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 3
+repeatable = 1
+minimum_required_age = 0
+
+["Abductors"]
+weight = 5
+min_pop = 20
+blacklisted_roles = []
+min_antag_cap = 2
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 3
+repeatable = 1
+minimum_required_age = 0
+
+["Space Ninja"]
+weight.1 = 0
+weight.2 = 0
+weight.3 = 1
+weight.4 = 2
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Revenant"]
+weight = 5
+min_pop = 10
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Midround Changeling"]
+weight = 5
+min_pop = 15
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Paradox Clone"]
+weight = 5
+min_pop = 10
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Voidwalker"]
+weight = 5
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Fugitives"]
+weight = 3
+min_pop = 20
+blacklisted_roles = []
+min_antag_cap = 3
+max_antag_cap = 4
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Morph"]
+weight = 0
+min_pop = 0
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Slaughter Demon"]
+weight = 0
+min_pop = 20
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Midround Traitor"]
+weight = 10
+min_pop = 3
+blacklisted_roles = [
+	"Head of Personnel",
+]
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Midround Malfunctioning AI"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+blacklisted_roles = []
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Blob Infection"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+blacklisted_roles = []
+repeatable_weight_decrease = 3
+repeatable = 1
+minimum_required_age = 0
+
+["Midround Obsessed"]
+weight.1 = 5
+weight.2 = 5
+weight.3 = 3
+weight.4 = 1
+min_pop = 5
+blacklisted_roles = []
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Roundstart Traitor"]
+weight = 10
+min_pop = 3
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap.denominator = 38
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Roundstart Malfunctioning AI"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Roundstart Blood Brothers"]
+weight = 5
+min_pop = 10
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap.denominator = 29
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Roundstart Changeling"]
+weight = 3
+min_pop = 15
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap.denominator = 29
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Roundstart Heretics"]
+weight = 3
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap.denominator = 24
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Roundstart Wizard"]
+weight.1 = 0
+weight.2 = 0
+weight.3 = 1
+weight.4 = 2
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 1
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Roundstart Blood Cult"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+blacklisted_roles = [
+	"Head of Personnel",
+]
+min_antag_cap.denominator = 20
+min_antag_cap.offset = 1
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Roundstart Nukeops"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap.denominator = 18
+min_antag_cap.offset = 1
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Roundstart Clownops"]
+weight = 0
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap.denominator = 18
+min_antag_cap.offset = 1
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Roundstart Revolution"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+blacklisted_roles = []
+min_antag_cap = 1
+max_antag_cap = 3
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Roundstart Spies"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 3
+weight.4 = 3
+min_pop = 10
+blacklisted_roles = []
+min_antag_cap.denominator = 20
+min_antag_cap.offset = 1
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 1
+minimum_required_age = 0
+
+["Extended"]
+weight = 0
+min_pop = 0
+blacklisted_roles = []
+min_antag_cap = 0
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Meteor"]
+weight = 0
+min_pop = 0
+blacklisted_roles = []
+min_antag_cap = 0
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0
+
+["Nations"]
+weight = 0
+min_pop = 0
+blacklisted_roles = []
+min_antag_cap = 0
+# max_antag_cap = min_antag_cap
+repeatable_weight_decrease = 2
+repeatable = 0
+minimum_required_age = 0


### PR DESCRIPTION
This PR contains an extensive tuning of the dynamic 2 configuration file on Terry.

The exact changes are too numerous to really list ; if you wish to see every change the single commit here https://github.com/tgstation-operations/server-config/commit/fb7e1e3257eb2ba3621ba148801c85f214b9eabf is the best reference (with the prior commit importing the defaults just to make this particular commit diff more useful)

The intention here in is to create "flavours" of rounds within the 4 tiers of dynamic in play:
Yellow Star - more minor or localised threats that won't end the round and players could opt in to or out of.
Orange Star - more global threats, but no round start round enders.  Chance of midround round enders (e.g. nukies) though.  Essentially goal is to make rounds to past the 30 min mark.
Red Star - Global threats plus good chance of a round start round ender meaning these rounds may be shorter in duration.
Black Orbit - Sustained global threats, preferably not round ender spam but anything is possible, sustained creation of light and heavy midrounds including round enders, goal being to end the station via attrition ideally, with the station having several victories before being overwhelmed (hopefully, you never know with Terry).

I include as reference the spreadsheet used to build out these.  Expressed in HTML and wrapped in a ZIP because apparently github doesn't like HTML attachments.  This contains all the values in the configuration in a format that helped me compare and contrast the tiers and balance as I tweaked some numbers.  Some of the comments are out of date or just meaningless waffle but the coloured section on antag weights is most insightful for tuning by tiers.

[Terry Dynamic.zip](https://github.com/user-attachments/files/21197225/Terry.Dynamic.zip)
