### PR TITLE
Remove kicking inactive players from terry/sybil

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -92,7 +92,8 @@ INACTIVITY_PERIOD 300
 AFK_PERIOD 600
 
 ## disconnect players who are considered afk
-KICK_INACTIVE
+# iain0 - moved to per server configs, only on manuel
+#KICK_INACTIVE
 
 ## Comment this out to stop admins being able to choose their personal ooccolor
 ALLOW_ADMIN_OOCCOLOR

--- a/manuel/config.txt
+++ b/manuel/config.txt
@@ -77,3 +77,6 @@ ROUNDSTART_BLUE_ALERT 0
 ALLOW_RANDOM_EVENTS
 ROUNDSTART_AWAY
 ENABLE_NIGHT_SHIFTS
+
+# made per server and only on manuel due to its pop caps
+KICK_INACTIVE


### PR DESCRIPTION
Config element KICK_INACTIVE removed from shared config.txt and moved to per server on manuel only (only server with an impactful pop cap).
