### PR TITLE
Dynamic Proposal Tweak

### DIFF
--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -35,16 +35,16 @@ min_pop = 0
 weight = 20
 advisory_report = "Advisory Level: <b>Yellow Star</b></center><BR>Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
 ruleset_type_settings.roundstart.low = 2
-ruleset_type_settings.roundstart.high = 2
+ruleset_type_settings.roundstart.high = 3
 ruleset_type_settings.roundstart.half_range_pop_threshold = 15
 ruleset_type_settings.roundstart.full_range_pop_threshold = 25
 ruleset_type_settings.light_midround.low = 1
 ruleset_type_settings.light_midround.high = 2
 ruleset_type_settings.light_midround.half_range_pop_threshold = 15
 ruleset_type_settings.light_midround.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.time_threshold = 25
-ruleset_type_settings.light_midround.execution_cooldown_low = 15
-ruleset_type_settings.light_midround.execution_cooldown_high = 25
+ruleset_type_settings.light_midround.time_threshold = 20
+ruleset_type_settings.light_midround.execution_cooldown_low = 12
+ruleset_type_settings.light_midround.execution_cooldown_high = 20
 ruleset_type_settings.heavy_midround.low = 0
 ruleset_type_settings.heavy_midround.high = 0
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
@@ -73,14 +73,14 @@ ruleset_type_settings.light_midround.low = 1
 ruleset_type_settings.light_midround.high = 2
 ruleset_type_settings.light_midround.half_range_pop_threshold = 15
 ruleset_type_settings.light_midround.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.time_threshold = 30
-ruleset_type_settings.light_midround.execution_cooldown_low = 10
-ruleset_type_settings.light_midround.execution_cooldown_high = 15
+ruleset_type_settings.light_midround.time_threshold = 25
+ruleset_type_settings.light_midround.execution_cooldown_low = 8
+ruleset_type_settings.light_midround.execution_cooldown_high = 12
 ruleset_type_settings.heavy_midround.low = 1
 ruleset_type_settings.heavy_midround.high = 2
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
-ruleset_type_settings.heavy_midround.time_threshold = 40
+ruleset_type_settings.heavy_midround.time_threshold = 35
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
 ruleset_type_settings.latejoin.low = 0
@@ -93,7 +93,7 @@ ruleset_type_settings.latejoin.execution_cooldown_high = 20
 
 ["Medium-High Chaos"]
 name = "Red Star"
-min_pop = 20
+min_pop = 15
 weight = 30
 advisory_report = "Advisory Level: <b>Red Star</b></center><BR>Your sector's advisory level is Red Star. Multiple communications signals in your sector have been intercepted, with partial success in decryption. Analysis combined with information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of impending attacks. Remain on high alert and vigilant against any potential threats."
 ruleset_type_settings.roundstart.low = 2
@@ -135,9 +135,9 @@ ruleset_type_settings.light_midround.low = 1
 ruleset_type_settings.light_midround.high = 1
 ruleset_type_settings.light_midround.half_range_pop_threshold = 15
 ruleset_type_settings.light_midround.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.time_threshold = 20
-ruleset_type_settings.light_midround.execution_cooldown_low = 10
-ruleset_type_settings.light_midround.execution_cooldown_high = 15
+ruleset_type_settings.light_midround.time_threshold = 15
+ruleset_type_settings.light_midround.execution_cooldown_low = 8
+ruleset_type_settings.light_midround.execution_cooldown_high = 12
 ruleset_type_settings.heavy_midround.low = 5
 ruleset_type_settings.heavy_midround.high = 5
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
@@ -184,26 +184,26 @@ min_pop = 30
 repeatable = 0
 
 ["Spiders"]
-weight.1 = 10
-weight.2 = 10
-weight.3 = 10
-weight.4 = 10
+weight.1 = 5
+weight.2 = 5
+weight.3 = 5
+weight.4 = 7
 min_pop = 30
 repeatable_weight_decrease = 4
 
 ["Light Pirates"]
-weight.1 = 2
-weight.2 = 3
-weight.3 = 3
-weight.4 = 5
+weight.1 = 1
+weight.2 = 2
+weight.3 = 2
+weight.4 = 3
 min_pop = 15
 repeatable_weight_decrease = 2
 
 ["Heavy Pirates"]
-weight.1 = 5
-weight.2 = 5
-weight.3 = 5
-weight.4 = 5
+weight.1 = 3
+weight.2 = 3
+weight.3 = 3
+weight.4 = 4
 min_pop = 25
 repeatable_weight_decrease = 4
 
@@ -229,34 +229,34 @@ min_pop = 30
 repeatable = 0
 
 ["Blob"]
-weight.1 = 2
-weight.2 = 1
-weight.3 = 2
-weight.4 = 5
+weight.1 = 3
+weight.2 = 2
+weight.3 = 3
+weight.4 = 7
 min_pop = 30
 repeatable_weight_decrease = 3
 
 ["Xenomorph"]
-weight.1 = 10
-weight.2 = 10
-weight.3 = 10
-weight.4 = 10
+weight.1 = 5
+weight.2 = 5
+weight.3 = 5
+weight.4 = 7
 min_pop = 30
 repeatable_weight_decrease = 4
 
 ["Nightmare"]
-weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.4 = 10
+weight.1 = 2
+weight.2 = 3
+weight.3 = 3
+weight.4 = 5
 min_pop = 15
 repeatable_weight_decrease = 3
 
 ["Space Dragon"]
-weight.1 = 10
-weight.2 = 5
-weight.3 = 10
-weight.4 = 10
+weight.1 = 5
+weight.2 = 3
+weight.3 = 5
+weight.4 = 7
 min_pop = 30
 repeatable_weight_decrease = 4
 
@@ -269,10 +269,10 @@ min_pop = 20
 repeatable_weight_decrease = 3
 
 ["Space Ninja"]
-weight.1 = 10
-weight.2 = 5
-weight.3 = 10
-weight.4 = 10
+weight.1 = 5
+weight.2 = 3
+weight.3 = 5
+weight.4 = 7
 min_pop = 30
 repeatable_weight_decrease = 4
 
@@ -356,7 +356,7 @@ min_pop = 5
 repeatable_weight_decrease = 3
 
 ["Roundstart Traitor"]
-weight = 10
+weight = 15
 min_pop = 3
 repeatable_weight_decrease = 4
 
@@ -377,19 +377,19 @@ min_pop = 10
 repeatable_weight_decrease = 4
 
 ["Roundstart Changeling"]
-weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.4 = 10
+weight.1 = 5
+weight.2 = 7
+weight.3 = 7
+weight.4 = 12
 min_pop = 15
 repeatable_weight_decrease = 3
 
 ["Roundstart Heretics"]
-weight.1 = 0
-weight.2 = 3
-weight.3 = 5
-weight.4 = 10
-min_pop = 30
+weight.1 = 1
+weight.2 = 5
+weight.3 = 7
+weight.4 = 12
+min_pop = 25
 repeatable_weight_decrease = 3
 
 ["Roundstart Wizard"]
@@ -401,11 +401,11 @@ min_pop = 30
 repeatable = 0
 
 ["Roundstart Blood Cult"]
-weight.1 = 0
-weight.2 = 0
-weight.3 = 3
-weight.4 = 5
-min_pop = 30
+weight.1 = 1
+weight.2 = 1
+weight.3 = 5
+weight.4 = 7
+min_pop = 25
 repeatable = 0
 
 ["Roundstart Nukeops"]
@@ -422,11 +422,11 @@ min_pop = 30
 repeatable = 0
 
 ["Roundstart Revolution"]
-weight.1 = 0
-weight.2 = 0
-weight.3 = 3
-weight.4 = 5
-min_pop = 30
+weight.1 = 1
+weight.2 = 1
+weight.3 = 5
+weight.4 = 7
+min_pop = 25
 repeatable = 0
 
 ["Roundstart Spies"]

--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -1,5 +1,5 @@
 ["Greenshift"]
-weight = 0
+weight = 5
 name = "Blue Star"
 min_pop = 0
 advisory_report = "Advisory Level: Advisory Level: <b>Blue Star</b></center><BR>Your sector's advisory level is Blue Star. Surveillance shows low levels of enemy activity in the sector.  We advise a normal working routine with increased vigilance."
@@ -32,7 +32,7 @@ ruleset_type_settings.latejoin.execution_cooldown_high = 30
 ["Low Chaos"]
 name = "Yellow Star"
 min_pop = 0
-weight = 10
+weight = 20
 advisory_report = "Advisory Level: <b>Yellow Star</b></center><BR>Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
 ruleset_type_settings.roundstart.low = 2
 ruleset_type_settings.roundstart.high = 2
@@ -63,7 +63,7 @@ ruleset_type_settings.latejoin.execution_cooldown_high = 30
 ["Low-Medium Chaos"]
 name = "Orange Star"
 min_pop = 10
-weight = 45
+weight = 35
 advisory_report = "Advisory Level: <b>Orange Star</b></center><BR>Your sector's advisory level is Orange Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
 ruleset_type_settings.roundstart.low = 2
 ruleset_type_settings.roundstart.high = 4
@@ -94,7 +94,7 @@ ruleset_type_settings.latejoin.execution_cooldown_high = 20
 ["Medium-High Chaos"]
 name = "Red Star"
 min_pop = 20
-weight = 35
+weight = 30
 advisory_report = "Advisory Level: <b>Red Star</b></center><BR>Your sector's advisory level is Red Star. Multiple communications signals in your sector have been intercepted, with partial success in decryption. Analysis combined with information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of impending attacks. Remain on high alert and vigilant against any potential threats."
 ruleset_type_settings.roundstart.low = 2
 ruleset_type_settings.roundstart.high = 4
@@ -125,7 +125,7 @@ ruleset_type_settings.latejoin.execution_cooldown_high = 15
 ["High Chaos"]
 name = "Black Orbit"
 min_pop = 30
-weight = 10
+weight = 15
 advisory_report = "Advisory Level: <b>Black Orbit</b></center><BR>Your sector's advisory level is Black Orbit. Multiple jamming signals in your region limit intelligence and render traditional classifications inapplicable.  Analysis suggests a mask to cover a large scale mobilisation in the region, or multiple significant independent threats.  Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
 ruleset_type_settings.roundstart.low = 2
 ruleset_type_settings.roundstart.high = 3
@@ -135,14 +135,14 @@ ruleset_type_settings.light_midround.low = 1
 ruleset_type_settings.light_midround.high = 1
 ruleset_type_settings.light_midround.half_range_pop_threshold = 15
 ruleset_type_settings.light_midround.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.time_threshold = 15
-ruleset_type_settings.light_midround.execution_cooldown_low = 7
-ruleset_type_settings.light_midround.execution_cooldown_high = 13
+ruleset_type_settings.light_midround.time_threshold = 20
+ruleset_type_settings.light_midround.execution_cooldown_low = 10
+ruleset_type_settings.light_midround.execution_cooldown_high = 15
 ruleset_type_settings.heavy_midround.low = 5
 ruleset_type_settings.heavy_midround.high = 5
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
-ruleset_type_settings.heavy_midround.time_threshold = 30
+ruleset_type_settings.heavy_midround.time_threshold = 45
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
 ruleset_type_settings.latejoin.low = 1
@@ -212,7 +212,7 @@ weight.1 = 1
 weight.2 = 0
 weight.3 = 1
 weight.4 = 5
-min_pop = 30
+min_pop = 25
 repeatable_weight_decrease = 2
 
 ["Midround Nukeops"]
@@ -220,7 +220,7 @@ weight.1 = 2
 weight.2 = 1
 weight.3 = 2
 weight.4 = 5
-min_pop = 30
+min_pop = 25
 repeatable = 0
 
 ["Midround Clownops"]
@@ -317,12 +317,12 @@ min_pop = 20
 repeatable = 0
 
 ["Morph"]
-weight = 0
+weight = 3
 min_pop = 0
 repeatable_weight_decrease = 2
 
 ["Slaughter Demon"]
-weight = 0
+weight = 2
 min_pop = 20
 repeatable_weight_decrease = 2
 
@@ -365,7 +365,7 @@ weight.1 = 0
 weight.2 = 0
 weight.3 = 3
 weight.4 = 5
-min_pop = 30
+min_pop = 25
 repeatable = 0
 
 ["Roundstart Blood Brothers"]
@@ -438,7 +438,7 @@ min_pop = 10
 repeatable_weight_decrease = 4
 
 ["Extended"]
-weight = 0
+weight = 1
 min_pop = 0
 
 ["Meteor"]

--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -1,5 +1,5 @@
 ["Greenshift"]
-weight = 5
+weight = 0
 name = "Blue Star"
 min_pop = 0
 advisory_report = "Advisory Level: Advisory Level: <b>Blue Star</b></center><BR>Your sector's advisory level is Blue Star. Surveillance shows low levels of enemy activity in the sector.  We advise a normal working routine with increased vigilance."
@@ -32,7 +32,7 @@ ruleset_type_settings.latejoin.execution_cooldown_high = 30
 ["Low Chaos"]
 name = "Yellow Star"
 min_pop = 0
-weight = 20
+weight = 15
 advisory_report = "Advisory Level: <b>Yellow Star</b></center><BR>Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
 ruleset_type_settings.roundstart.low = 2
 ruleset_type_settings.roundstart.high = 3
@@ -93,7 +93,7 @@ ruleset_type_settings.latejoin.execution_cooldown_high = 20
 
 ["Medium-High Chaos"]
 name = "Red Star"
-min_pop = 15
+min_pop = 20
 weight = 30
 advisory_report = "Advisory Level: <b>Red Star</b></center><BR>Your sector's advisory level is Red Star. Multiple communications signals in your sector have been intercepted, with partial success in decryption. Analysis combined with information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of impending attacks. Remain on high alert and vigilant against any potential threats."
 ruleset_type_settings.roundstart.low = 2
@@ -142,7 +142,7 @@ ruleset_type_settings.heavy_midround.low = 5
 ruleset_type_settings.heavy_midround.high = 5
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
-ruleset_type_settings.heavy_midround.time_threshold = 45
+ruleset_type_settings.heavy_midround.time_threshold = 30
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
 ruleset_type_settings.latejoin.low = 1
@@ -317,12 +317,12 @@ min_pop = 20
 repeatable = 0
 
 ["Morph"]
-weight = 3
+weight = 0
 min_pop = 0
 repeatable_weight_decrease = 2
 
 ["Slaughter Demon"]
-weight = 2
+weight = 0
 min_pop = 20
 repeatable_weight_decrease = 2
 
@@ -356,7 +356,7 @@ min_pop = 5
 repeatable_weight_decrease = 3
 
 ["Roundstart Traitor"]
-weight = 15
+weight = 12
 min_pop = 3
 repeatable_weight_decrease = 4
 
@@ -365,7 +365,7 @@ weight.1 = 0
 weight.2 = 0
 weight.3 = 3
 weight.4 = 5
-min_pop = 25
+min_pop = 30
 repeatable = 0
 
 ["Roundstart Blood Brothers"]
@@ -385,8 +385,8 @@ min_pop = 15
 repeatable_weight_decrease = 3
 
 ["Roundstart Heretics"]
-weight.1 = 1
-weight.2 = 5
+weight.1 = 0
+weight.2 = 0
 weight.3 = 7
 weight.4 = 12
 min_pop = 25
@@ -401,8 +401,8 @@ min_pop = 30
 repeatable = 0
 
 ["Roundstart Blood Cult"]
-weight.1 = 1
-weight.2 = 1
+weight.1 = 0
+weight.2 = 0
 weight.3 = 5
 weight.4 = 7
 min_pop = 25
@@ -422,8 +422,8 @@ min_pop = 30
 repeatable = 0
 
 ["Roundstart Revolution"]
-weight.1 = 1
-weight.2 = 1
+weight.1 = 0
+weight.2 = 0
 weight.3 = 5
 weight.4 = 7
 min_pop = 25
@@ -438,7 +438,7 @@ min_pop = 10
 repeatable_weight_decrease = 4
 
 ["Extended"]
-weight = 1
+weight = 0
 min_pop = 0
 
 ["Meteor"]


### PR DESCRIPTION
See here for discussion: https://forums.tgstation13.org/viewtopic.php?t=39186

# Dynamic Configuration Overhaul

Current dynamic config causes player fatigue with 80% medium+ threat rounds, repetitive antag types, and disabled peaceful content.

# Expected Impact:
- Much better variety - No more "Xenomorph/Spider/Dragon every round" 
- Classic antag revival - Traitors, Changelings, Heretics more common
- Balanced threat escalation - Yellow feels harsher, Orange distinct from Yellow 
- Better population scaling - 15-25 player rounds get high-tier content 
- Earlier action - Events start happening sooner, less dead time

## What has been changed

- Enabled Greenshift - Weight 0 > 5 (allows peaceful rounds now and then for more spread out mixture) 
- Rebalanced threat levels - More low-chaos, less medium-chaos dominance
- Fixed High Chaos timing - Events now spread out properly to prevent overwhelming cascades 
- Improved population scaling - Lowered some 30-player minimums to 25
- Restored disabled content - Morph, Slaughter Demon, and Extended now have weights
- Extended is back but in a 1 every 100+ round chance

## Common antags:

Spiders: 10>5-7 (was way too frequent)
Pirates (Light/Heavy): Reduced across all threat levels
Xenomorphs: 10>5-7 (half as common)
Nightmares: 3-10>2-5 (significant reduction)
Space Dragons: 10>5-7 (less overwhelming)
Space Ninja: 10>5-7 (better balance)

## Not common antags:

Roundstart Traitors: 10>15 (A classic)
Heretics: Added weight in lower threat levels, 10 >12 
Changelings: Boosted significantly across all levels
Blood Cult: Now possible in lower threat levels (1-1-5-7)
Revolution: Same boost pattern as Cult
Blob: Increased from 2-1-2-5 to 3-2-3-7

## Yellow vs Orange Star Differentiation

**Yellow Star is now more harsh:**
- Higher max roundstart antags (2>3)
- Faster midround events (25>20 minutes)
- Shorter cooldowns (15-25>12-20 minutes)

**Orange Star is more distinct:**
- Earlier heavy midround (40>35 minutes)
- Much faster light midround cycles (10-15>8-12 minutes)
- Creates clear escalation from Yellow

## Population Scaling Improvements
Red Star: 20>15 minimum (fixes the 15-19 player dead zone)
Cult/Revs/Heretics: 30>25 minimum (accessible to more rounds)
Better mid-population content access

## Early Game Content
High Chaos light midround: Now starts at 15 minutes (was 20)
Faster event cycling in higher threat levels
More content before the 30-45 minute mark