### PR TITLE
Manuel config update 1.1: fuck it we ball 11/18/2025

### DIFF
--- a/manuel/dynamic.toml
+++ b/manuel/dynamic.toml
@@ -1,19 +1,482 @@
 ["Greenshift"]
-name = "Green Alert"
-advisory_report = "Central Command Alert Level: <b>Green</b></center><BR>At this time Central Command is receiving the all clear from intelligence assets across this region."
+name = "Blue Star"
+min_pop = 0
+weight = 2
+advisory_report = "Advisory Level: <b>Green Star</b></center><BR>Your sector's advisory level is Green Star. Surveillance information shows no credible threats to Nanotrasen assets within the Spinward Sector at this time. As always, the Department advises maintaining vigilance against potential threats, regardless of a lack of known threats."
+ruleset_type_settings.roundstart.low = 0
+ruleset_type_settings.roundstart.high = 0
+ruleset_type_settings.roundstart.half_range_pop_threshold = 25
+ruleset_type_settings.roundstart.full_range_pop_threshold = 50
+ruleset_type_settings.light_midround.low = 0
+ruleset_type_settings.light_midround.high = 0
+ruleset_type_settings.light_midround.half_range_pop_threshold = 25
+ruleset_type_settings.light_midround.full_range_pop_threshold = 40
+ruleset_type_settings.light_midround.time_threshold = 30
+ruleset_type_settings.light_midround.execution_cooldown_low = 10
+ruleset_type_settings.light_midround.execution_cooldown_high = 20
+ruleset_type_settings.heavy_midround.low = 0
+ruleset_type_settings.heavy_midround.high = 0
+ruleset_type_settings.heavy_midround.half_range_pop_threshold = 25
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 40
+ruleset_type_settings.heavy_midround.time_threshold = 60
+ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
+ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
+ruleset_type_settings.latejoin.low = 0
+ruleset_type_settings.latejoin.high = 0
+ruleset_type_settings.latejoin.half_range_pop_threshold = 25
+ruleset_type_settings.latejoin.full_range_pop_threshold = 40
+ruleset_type_settings.latejoin.time_threshold = 0
+ruleset_type_settings.latejoin.execution_cooldown_low = 10
+ruleset_type_settings.latejoin.execution_cooldown_high = 20
 
 ["Low Chaos"]
-name = "Blue Alert"
-advisory_report = "Central Command Alert Level: <b>Blue</b></center><BR>Central Command has received unreliable rumours of activity within the region, and has increased our intelligence resourcing accordingly.  Further updates about any confirmed threats will be forwarded to the relevant facilities."
+name = "Yellow Star"
+min_pop = 0
+weight = 23
+advisory_report = "Advisory Level: <b>Yellow Star</b></center><BR>Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
+ruleset_type_settings.roundstart.low = 1
+ruleset_type_settings.roundstart.high = 2
+ruleset_type_settings.roundstart.half_range_pop_threshold = 18
+ruleset_type_settings.roundstart.full_range_pop_threshold = 21
+ruleset_type_settings.light_midround.low = 3
+ruleset_type_settings.light_midround.high = 4
+ruleset_type_settings.light_midround.half_range_pop_threshold = 18
+ruleset_type_settings.light_midround.full_range_pop_threshold = 21
+ruleset_type_settings.light_midround.time_threshold = 35
+ruleset_type_settings.light_midround.execution_cooldown_low = 15
+ruleset_type_settings.light_midround.execution_cooldown_high = 21
+ruleset_type_settings.heavy_midround.low = 0
+ruleset_type_settings.heavy_midround.high = 1
+ruleset_type_settings.heavy_midround.half_range_pop_threshold = 18
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
+ruleset_type_settings.heavy_midround.time_threshold = 50
+ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
+ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
+ruleset_type_settings.latejoin.low = 0
+ruleset_type_settings.latejoin.high = 2
+ruleset_type_settings.latejoin.half_range_pop_threshold = 18
+ruleset_type_settings.latejoin.full_range_pop_threshold = 21
+ruleset_type_settings.latejoin.time_threshold = 15
+ruleset_type_settings.latejoin.execution_cooldown_low = 15
+ruleset_type_settings.latejoin.execution_cooldown_high = 30
 
 ["Low-Medium Chaos"]
-name = "Yellow Alert"
-advisory_report = "Central Command Alert Level: <b>Yellow</b></center><BR>Central Command has received reports of hostile unit movements in the region suggesting a possible attack against one of our facilities.  We have increased our surveilance and will forward any further details to the relevant facilities."
+name = "Orange Star"
+min_pop = 18
+weight = 38
+advisory_report = "Advisory Level: <b>Orange Star</b></center><BR>Your sector's advisory level is Orange Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
+ruleset_type_settings.roundstart.low = 2
+ruleset_type_settings.roundstart.high = 2
+ruleset_type_settings.roundstart.half_range_pop_threshold = 18
+ruleset_type_settings.roundstart.full_range_pop_threshold = 22
+ruleset_type_settings.light_midround.low = 2
+ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.light_midround.half_range_pop_threshold = 18
+ruleset_type_settings.light_midround.full_range_pop_threshold = 22
+ruleset_type_settings.light_midround.time_threshold = 35
+ruleset_type_settings.light_midround.execution_cooldown_low = 10
+ruleset_type_settings.light_midround.execution_cooldown_high = 15
+ruleset_type_settings.heavy_midround.low = 1
+ruleset_type_settings.heavy_midround.high = 2
+ruleset_type_settings.heavy_midround.half_range_pop_threshold = 18
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 30
+ruleset_type_settings.heavy_midround.time_threshold = 45
+ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
+ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
+ruleset_type_settings.latejoin.low = 1
+ruleset_type_settings.latejoin.high = 2
+ruleset_type_settings.latejoin.half_range_pop_threshold = 18
+ruleset_type_settings.latejoin.full_range_pop_threshold = 21
+ruleset_type_settings.latejoin.time_threshold = 20
+ruleset_type_settings.latejoin.execution_cooldown_low = 10
+ruleset_type_settings.latejoin.execution_cooldown_high = 20
 
 ["Medium-High Chaos"]
-name = "Red Alert"
-advisory_report = "Central Command Alert Level: <b>Red</b></center><BR>Central Command has received multiple confirmed reports of hostile movements in the region, we are anticipating a strike against multiple assets or a co-ordinated assault on one.  We have mobilised to full intelligence alertness and will provide relevant facilities with updates as more information is obtained.  Facilities should await updates, remain vigilant and productive."
+name = "Red Star"
+min_pop = 30
+weight = 23
+advisory_report = "Advisory Level: <b>Red Star</b></center><BR>Your sector's advisory level is Red Star. Multiple communications signals in your sector have been intercepted, with partial success in decryption. Analysis combined with information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of impending attacks. Remain on high alert and vigilant against any potential threats."
+ruleset_type_settings.roundstart.low = 2
+ruleset_type_settings.roundstart.high = 2
+ruleset_type_settings.roundstart.half_range_pop_threshold = 15
+ruleset_type_settings.roundstart.full_range_pop_threshold = 30
+ruleset_type_settings.light_midround.low = 1
+ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.light_midround.half_range_pop_threshold = 15
+ruleset_type_settings.light_midround.full_range_pop_threshold = 30
+ruleset_type_settings.light_midround.time_threshold = 35
+ruleset_type_settings.light_midround.execution_cooldown_low = 10
+ruleset_type_settings.light_midround.execution_cooldown_high = 15
+ruleset_type_settings.heavy_midround.low = 1
+ruleset_type_settings.heavy_midround.high = 2
+ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 30
+ruleset_type_settings.heavy_midround.time_threshold = 50
+ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
+ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
+ruleset_type_settings.latejoin.low = 0
+ruleset_type_settings.latejoin.high = 2
+ruleset_type_settings.latejoin.half_range_pop_threshold = 15
+ruleset_type_settings.latejoin.full_range_pop_threshold = 21
+ruleset_type_settings.latejoin.time_threshold = 10
+ruleset_type_settings.latejoin.execution_cooldown_low = 5
+ruleset_type_settings.latejoin.execution_cooldown_high = 10
 
 ["High Chaos"]
-name = "Black Alert"
-advisory_report = "Central Command Alert Level: <b>Black</b></center><BR>Central Command Intelligence Network is currently down due to combined remote jamming signals.  Forces have been dispatched to the originating sites and we anticipate restoration of service and a revision of the alert level in a few days. This jamming may represent an impending attack within the region, however enemy forces also deploy jamming as counter-value causing unnecessary disruption and expense to respond to.  We advise all facilities to remain vigilant and continue normal operations until we can provide additional information."
+name = "Black Orbit"
+min_pop = 30
+weight = 14
+advisory_report = "Advisory Level: <b>Black Orbit</b></center><BR>Your sector's advisory level is Black Orbit. Multiple jamming signals in your region limit intelligence and render traditional classifications inapplicable.  Analysis suggests a mask to cover a large scale mobilisation in the region, or multiple significant independent threats.  Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
+ruleset_type_settings.roundstart.low = 2
+ruleset_type_settings.roundstart.high = 3
+ruleset_type_settings.roundstart.half_range_pop_threshold = 15
+ruleset_type_settings.roundstart.full_range_pop_threshold = 25
+ruleset_type_settings.light_midround.low = 1
+ruleset_type_settings.light_midround.high = 1
+ruleset_type_settings.light_midround.half_range_pop_threshold = 15
+ruleset_type_settings.light_midround.full_range_pop_threshold = 25
+ruleset_type_settings.light_midround.time_threshold = 25
+ruleset_type_settings.light_midround.execution_cooldown_low = 5
+ruleset_type_settings.light_midround.execution_cooldown_high = 10
+ruleset_type_settings.heavy_midround.low = 2
+ruleset_type_settings.heavy_midround.high = 4
+ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
+ruleset_type_settings.heavy_midround.time_threshold = 35
+ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
+ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
+ruleset_type_settings.latejoin.low = 1
+ruleset_type_settings.latejoin.high = 2
+ruleset_type_settings.latejoin.half_range_pop_threshold = 15
+ruleset_type_settings.latejoin.full_range_pop_threshold = 21
+ruleset_type_settings.latejoin.time_threshold = 5
+ruleset_type_settings.latejoin.execution_cooldown_low = 5
+ruleset_type_settings.latejoin.execution_cooldown_high = 10
+
+
+["Latejoin Traitor"]
+weight.1 = 10
+weight.2 = 14
+weight.3 = 10
+weight.4 = 10
+min_pop = 11
+repeatable_weight_decrease = 5
+
+["Latejoin Heretic"]
+weight.1 = 0
+weight.2 = 0
+weight.3 = 0
+weight.4 = 0
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Latejoin Changeling"]
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
+min_pop = 15
+repeatable_weight_decrease = 4
+
+["Latejoin Revolution"]
+weight.1 = 0
+weight.2 = 1
+weight.3 = 1
+weight.4 = 2
+min_pop = 30
+repeatable = 0
+
+["Spiders"]
+weight.1 = 10
+weight.2 = 5
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Light Pirates"]
+weight.1 = 2
+weight.2 = 3
+weight.3 = 3
+weight.4 = 5
+min_pop = 15
+repeatable_weight_decrease = 2
+
+["Heavy Pirates"]
+weight.1 = 3
+weight.2 = 3
+weight.3 = 3
+weight.4 = 3
+min_pop = 25
+repeatable_weight_decrease = 4
+
+["Midround Wizard"]
+weight.1 = 1
+weight.2 = 1
+weight.3 = 3
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 2
+
+["Midround Nukeops"]
+weight.1 = 2
+weight.2 = 1
+weight.3 = 2
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Midround Clownops"]
+weight = 0
+min_pop = 30
+repeatable = 0
+
+["Blob"]
+weight.1 = 2
+weight.2 = 2
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+repeatable_weight_decrease = 3
+
+["Xenomorph"]
+weight.1 = 10
+weight.2 = 5
+weight.3 = 8
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Nightmare"]
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 7
+min_pop = 15
+repeatable_weight_decrease = 5
+
+["Space Dragon"]
+weight.1 = 5
+weight.2 = 5
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Abductors"]
+weight.1 = 6
+weight.2 = 6
+weight.3 = 6
+weight.4 = 5
+min_pop = 20
+repeatable_weight_decrease = 3
+
+["Space Ninja"]
+weight.1 = 10
+weight.2 = 10
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 5
+
+["Revenant"]
+weight.1 = 5
+weight.2 = 3
+weight.3 = 3
+weight.4 = 2
+min_pop = 10
+repeatable = 0
+
+["Midround Changeling"]
+weight.1 = 7
+weight.2 = 7
+weight.3 = 8
+weight.10 = 10
+min_pop = 15
+repeatable_weight_decrease = 4
+
+["Midround Mass Changelings"]
+weight.1 = 0
+weight.2 = 4
+weight.3 = 4
+weight.4 = 4
+min_pop = 25
+blacklisted_roles = []
+repeatable_weight_decrease = 4
+repeatable = 1
+min_antag_cap = 2
+max_antag_cap = 3
+
+["Paradox Clone"]
+weight.1 = 8
+weight.2 = 8
+weight.3 = 10
+weight.4 = 10
+min_pop = 10
+repeatable_weight_decrease = 4
+
+["Voidwalker"]
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
+min_pop = 30
+repeatable_weight_decrease = 3
+
+["Fugitives"]
+weight.1 = 8
+weight.2 = 8
+weight.3 = 5
+weight.4 = 5
+min_pop = 20
+repeatable = 0
+
+["Morph"]
+weight = 0
+min_pop = 0
+repeatable_weight_decrease = 2
+
+["Slaughter Demon"]
+weight = 0
+min_pop = 20
+repeatable_weight_decrease = 2
+
+["Midround Traitor"]
+weight.1 = 15
+weight.2 = 10
+weight.3 = 10
+weight.4 = 10
+min_pop = 11
+repeatable_weight_decrease = 4
+
+["Midround Mass Traitors"]
+weight.1 = 5
+weight.2 = 8
+weight.3 = 8
+weight.4 = 5
+min_pop = 15
+repeatable_weight_decrease = 8
+repeatable = 1
+min_antag_cap = 2
+max_antag_cap = 3
+
+["Midround Malfunctioning AI"]
+weight.1 = 5
+weight.2 = 2
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Blob Infection"]
+weight.1 = 4
+weight.2 = 2
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Midround Obsessed"]
+weight.1 = 8
+weight.2 = 8
+weight.3 = 5
+weight.4 = 5
+min_pop = 5
+repeatable_weight_decrease = 4
+
+["Roundstart Traitor"]
+weight.1 = 12
+weight.2 = 12
+weight.3 = 5
+weight.4 = 7
+min_pop = 11
+repeatable_weight_decrease = 4
+
+["Roundstart Malfunctioning AI"]
+weight.1 = 1
+weight.2 = 3
+weight.3 = 3
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Roundstart Blood Brothers"]
+weight.1 = 12
+weight.2 = 7
+weight.3 = 3
+weight.4 = 0
+min_pop = 11
+repeatable_weight_decrease = 4
+
+["Roundstart Changeling"]
+weight.1 = 5
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
+min_pop = 15
+repeatable_weight_decrease = 3
+
+["Roundstart Heretics"]
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
+min_pop = 30
+repeatable_weight_decrease = 3
+
+["Roundstart Wizard"]
+weight.1 = 1
+weight.2 = 1
+weight.3 = 3
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Roundstart Blood Cult"]
+weight.1 = 1
+weight.2 = 3
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Roundstart Nukeops"]
+weight.1 = 1
+weight.2 = 3
+weight.3 = 3
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Roundstart Clownops"]
+weight = 0
+min_pop = 30
+repeatable = 0
+
+["Roundstart Revolution"]
+weight.1 = 2
+weight.2 = 4
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Roundstart Spies"]
+weight.1 = 10
+weight.2 = 5
+weight.3 = 3
+weight.4 = 8
+min_pop = 10
+repeatable_weight_decrease = 4
+
+["Extended"]
+weight = 0
+min_pop = 0
+
+["Meteor"]
+weight = 0
+min_pop = 0
+
+["Nations"]
+weight = 0
+min_pop = 0

--- a/manuel/dynamic.toml
+++ b/manuel/dynamic.toml
@@ -34,29 +34,29 @@ name = "Yellow Star"
 min_pop = 0
 weight = 23
 advisory_report = "Advisory Level: <b>Yellow Star</b></center><BR>Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
-ruleset_type_settings.roundstart.low = 1
-ruleset_type_settings.roundstart.high = 2
+ruleset_type_settings.roundstart.low = 2
+ruleset_type_settings.roundstart.high = 3
 ruleset_type_settings.roundstart.half_range_pop_threshold = 18
 ruleset_type_settings.roundstart.full_range_pop_threshold = 21
-ruleset_type_settings.light_midround.low = 3
-ruleset_type_settings.light_midround.high = 4
+ruleset_type_settings.light_midround.low = 4
+ruleset_type_settings.light_midround.high = 5
 ruleset_type_settings.light_midround.half_range_pop_threshold = 18
 ruleset_type_settings.light_midround.full_range_pop_threshold = 21
-ruleset_type_settings.light_midround.time_threshold = 35
-ruleset_type_settings.light_midround.execution_cooldown_low = 15
-ruleset_type_settings.light_midround.execution_cooldown_high = 21
-ruleset_type_settings.heavy_midround.low = 0
-ruleset_type_settings.heavy_midround.high = 1
+ruleset_type_settings.light_midround.time_threshold = 25
+ruleset_type_settings.light_midround.execution_cooldown_low = 10
+ruleset_type_settings.light_midround.execution_cooldown_high = 15
+ruleset_type_settings.heavy_midround.low = 1
+ruleset_type_settings.heavy_midround.high = 2
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 18
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
 ruleset_type_settings.heavy_midround.time_threshold = 50
-ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
+ruleset_type_settings.heavy_midround.execution_cooldown_low = 15
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 0
+ruleset_type_settings.latejoin.low = 2
 ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 18
 ruleset_type_settings.latejoin.full_range_pop_threshold = 21
-ruleset_type_settings.latejoin.time_threshold = 15
+ruleset_type_settings.latejoin.time_threshold = 65
 ruleset_type_settings.latejoin.execution_cooldown_low = 15
 ruleset_type_settings.latejoin.execution_cooldown_high = 30
 
@@ -65,70 +65,70 @@ name = "Orange Star"
 min_pop = 18
 weight = 38
 advisory_report = "Advisory Level: <b>Orange Star</b></center><BR>Your sector's advisory level is Orange Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
-ruleset_type_settings.roundstart.low = 2
-ruleset_type_settings.roundstart.high = 2
+ruleset_type_settings.roundstart.low = 3
+ruleset_type_settings.roundstart.high = 3
 ruleset_type_settings.roundstart.half_range_pop_threshold = 18
 ruleset_type_settings.roundstart.full_range_pop_threshold = 22
-ruleset_type_settings.light_midround.low = 2
-ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.light_midround.low = 3
+ruleset_type_settings.light_midround.high = 3
 ruleset_type_settings.light_midround.half_range_pop_threshold = 18
 ruleset_type_settings.light_midround.full_range_pop_threshold = 22
 ruleset_type_settings.light_midround.time_threshold = 35
 ruleset_type_settings.light_midround.execution_cooldown_low = 10
 ruleset_type_settings.light_midround.execution_cooldown_high = 15
-ruleset_type_settings.heavy_midround.low = 1
-ruleset_type_settings.heavy_midround.high = 2
+ruleset_type_settings.heavy_midround.low = 2
+ruleset_type_settings.heavy_midround.high = 3
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 18
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 30
 ruleset_type_settings.heavy_midround.time_threshold = 45
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 1
+ruleset_type_settings.latejoin.low = 2
 ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 18
 ruleset_type_settings.latejoin.full_range_pop_threshold = 21
-ruleset_type_settings.latejoin.time_threshold = 20
+ruleset_type_settings.latejoin.time_threshold = 65
 ruleset_type_settings.latejoin.execution_cooldown_low = 10
 ruleset_type_settings.latejoin.execution_cooldown_high = 20
 
 ["Medium-High Chaos"]
 name = "Red Star"
-min_pop = 30
+min_pop = 23
 weight = 23
 advisory_report = "Advisory Level: <b>Red Star</b></center><BR>Your sector's advisory level is Red Star. Multiple communications signals in your sector have been intercepted, with partial success in decryption. Analysis combined with information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of impending attacks. Remain on high alert and vigilant against any potential threats."
-ruleset_type_settings.roundstart.low = 2
-ruleset_type_settings.roundstart.high = 2
+ruleset_type_settings.roundstart.low = 3
+ruleset_type_settings.roundstart.high = 3
 ruleset_type_settings.roundstart.half_range_pop_threshold = 15
 ruleset_type_settings.roundstart.full_range_pop_threshold = 30
-ruleset_type_settings.light_midround.low = 1
-ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.light_midround.low = 2
+ruleset_type_settings.light_midround.high = 3
 ruleset_type_settings.light_midround.half_range_pop_threshold = 15
 ruleset_type_settings.light_midround.full_range_pop_threshold = 30
 ruleset_type_settings.light_midround.time_threshold = 35
 ruleset_type_settings.light_midround.execution_cooldown_low = 10
 ruleset_type_settings.light_midround.execution_cooldown_high = 15
-ruleset_type_settings.heavy_midround.low = 1
-ruleset_type_settings.heavy_midround.high = 2
+ruleset_type_settings.heavy_midround.low = 2
+ruleset_type_settings.heavy_midround.high = 3
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 30
 ruleset_type_settings.heavy_midround.time_threshold = 50
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 0
-ruleset_type_settings.latejoin.high = 2
+ruleset_type_settings.latejoin.low = 2
+ruleset_type_settings.latejoin.high = 3
 ruleset_type_settings.latejoin.half_range_pop_threshold = 15
 ruleset_type_settings.latejoin.full_range_pop_threshold = 21
-ruleset_type_settings.latejoin.time_threshold = 10
+ruleset_type_settings.latejoin.time_threshold = 65
 ruleset_type_settings.latejoin.execution_cooldown_low = 5
 ruleset_type_settings.latejoin.execution_cooldown_high = 10
 
 ["High Chaos"]
 name = "Black Orbit"
-min_pop = 30
+min_pop = 23
 weight = 14
 advisory_report = "Advisory Level: <b>Black Orbit</b></center><BR>Your sector's advisory level is Black Orbit. Multiple jamming signals in your region limit intelligence and render traditional classifications inapplicable.  Analysis suggests a mask to cover a large scale mobilisation in the region, or multiple significant independent threats.  Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
-ruleset_type_settings.roundstart.low = 2
-ruleset_type_settings.roundstart.high = 3
+ruleset_type_settings.roundstart.low = 3
+ruleset_type_settings.roundstart.high = 4
 ruleset_type_settings.roundstart.half_range_pop_threshold = 15
 ruleset_type_settings.roundstart.full_range_pop_threshold = 25
 ruleset_type_settings.light_midround.low = 1
@@ -138,18 +138,18 @@ ruleset_type_settings.light_midround.full_range_pop_threshold = 25
 ruleset_type_settings.light_midround.time_threshold = 25
 ruleset_type_settings.light_midround.execution_cooldown_low = 5
 ruleset_type_settings.light_midround.execution_cooldown_high = 10
-ruleset_type_settings.heavy_midround.low = 2
-ruleset_type_settings.heavy_midround.high = 4
+ruleset_type_settings.heavy_midround.low = 3
+ruleset_type_settings.heavy_midround.high = 5
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
 ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
 ruleset_type_settings.heavy_midround.time_threshold = 35
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
-ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 1
-ruleset_type_settings.latejoin.high = 2
+ruleset_type_settings.heavy_midround.execution_cooldown_high = 15
+ruleset_type_settings.latejoin.low = 2
+ruleset_type_settings.latejoin.high = 3
 ruleset_type_settings.latejoin.half_range_pop_threshold = 15
 ruleset_type_settings.latejoin.full_range_pop_threshold = 21
-ruleset_type_settings.latejoin.time_threshold = 5
+ruleset_type_settings.latejoin.time_threshold = 55
 ruleset_type_settings.latejoin.execution_cooldown_low = 5
 ruleset_type_settings.latejoin.execution_cooldown_high = 10
 
@@ -288,18 +288,18 @@ min_pop = 10
 repeatable = 0
 
 ["Midround Changeling"]
-weight.1 = 7
-weight.2 = 7
-weight.3 = 8
-weight.10 = 10
+weight.1 = 8
+weight.2 = 9
+weight.3 = 9
+weight.10 = 13
 min_pop = 15
 repeatable_weight_decrease = 4
 
 ["Midround Mass Changelings"]
-weight.1 = 0
-weight.2 = 4
-weight.3 = 4
-weight.4 = 4
+weight.1 = 1
+weight.2 = 5
+weight.3 = 5
+weight.4 = 6
 min_pop = 25
 blacklisted_roles = []
 repeatable_weight_decrease = 4
@@ -342,18 +342,18 @@ min_pop = 20
 repeatable_weight_decrease = 2
 
 ["Midround Traitor"]
-weight.1 = 15
-weight.2 = 10
-weight.3 = 10
-weight.4 = 10
+weight.1 = 17
+weight.2 = 14
+weight.3 = 13
+weight.4 = 13
 min_pop = 11
 repeatable_weight_decrease = 4
 
 ["Midround Mass Traitors"]
-weight.1 = 5
-weight.2 = 8
-weight.3 = 8
-weight.4 = 5
+weight.1 = 7
+weight.2 = 11
+weight.3 = 10
+weight.4 = 7
 min_pop = 15
 repeatable_weight_decrease = 8
 repeatable = 1
@@ -385,10 +385,10 @@ min_pop = 5
 repeatable_weight_decrease = 4
 
 ["Roundstart Traitor"]
-weight.1 = 12
-weight.2 = 12
-weight.3 = 5
-weight.4 = 7
+weight.1 = 16
+weight.2 = 18
+weight.3 = 9
+weight.4 = 11
 min_pop = 11
 repeatable_weight_decrease = 4
 
@@ -397,31 +397,31 @@ weight.1 = 1
 weight.2 = 3
 weight.3 = 3
 weight.4 = 5
-min_pop = 30
+min_pop = 23
 repeatable = 0
 
 ["Roundstart Blood Brothers"]
-weight.1 = 12
-weight.2 = 7
-weight.3 = 3
-weight.4 = 0
+weight.1 = 14
+weight.2 = 9
+weight.3 = 5
+weight.4 = 2
 min_pop = 11
 repeatable_weight_decrease = 4
 
 ["Roundstart Changeling"]
-weight.1 = 5
-weight.2 = 5
-weight.3 = 5
-weight.4 = 10
+weight.1 = 7
+weight.2 = 9
+weight.3 = 9
+weight.4 = 17
 min_pop = 15
 repeatable_weight_decrease = 3
 
 ["Roundstart Heretics"]
-weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.4 = 10
-min_pop = 30
+weight.1 = 6
+weight.2 = 8
+weight.3 = 8
+weight.4 = 13
+min_pop = 23
 repeatable_weight_decrease = 3
 
 ["Roundstart Wizard"]
@@ -429,7 +429,7 @@ weight.1 = 1
 weight.2 = 1
 weight.3 = 3
 weight.4 = 5
-min_pop = 30
+min_pop = 23
 repeatable = 0
 
 ["Roundstart Blood Cult"]
@@ -437,7 +437,7 @@ weight.1 = 1
 weight.2 = 3
 weight.3 = 5
 weight.4 = 5
-min_pop = 30
+min_pop = 23
 repeatable = 0
 
 ["Roundstart Nukeops"]
@@ -445,7 +445,7 @@ weight.1 = 1
 weight.2 = 3
 weight.3 = 3
 weight.4 = 5
-min_pop = 30
+min_pop = 23
 repeatable = 0
 
 ["Roundstart Clownops"]
@@ -455,18 +455,18 @@ repeatable = 0
 
 ["Roundstart Revolution"]
 weight.1 = 2
-weight.2 = 4
-weight.3 = 5
-weight.4 = 5
-min_pop = 30
+weight.2 = 5
+weight.3 = 7
+weight.4 = 7
+min_pop = 23
 repeatable = 0
 
 ["Roundstart Spies"]
-weight.1 = 10
-weight.2 = 5
-weight.3 = 3
-weight.4 = 8
-min_pop = 10
+weight.1 = 11
+weight.2 = 7
+weight.3 = 4
+weight.4 = 10
+min_pop = 11
 repeatable_weight_decrease = 4
 
 ["Extended"]


### PR DESCRIPTION
### Change log 1.1-
**Ideal population is 30+ living players**
**Bluestar** has a **weight of 2 and 0 pop needed**
**Yellow star** has a **weight of 23 and 0 pop needed**
**Orange star** has a **weight of 38 and 18 pop needed**
**Red star** has a **weight of 23 and 23 pop needed**
**Black orbit** has a **weight of 14 and 23 pop needed**

### Population tied to orbit rolled
What does this look like for lower population rounds.
Thresholds of population are the following: 
                                      0            18-          23b              23 population needed.
Bluestar happens:         **8%**       **3.07%**      2.32%       **2%**
Yellow star happens:     **92%**     **35%**        26%           **23%**
orange star happens:     0-       **61.5%**     44.18%      **38%**
Red star happens:          0-       0-            26.74        **23%**
black orbit happens:      0-       0-            0-             **14%**
                                                                ^b) this column is for if red orbit was not 23.
**Roundstart thresholds** are down from 40 default on **yellow/orange star to 21-22 pop to get the full effect of high population that would experience.** This does **extend out to midrounds rolls as well.**

### Legacy Number of Rulesets for 1.0: fuck it we ball
**This is not the one we care about.**
Yellow was 1-1 to **1-2 roundstart**, 0-1 to **0-2 latejoin**, 0-2 to **3-4 lightmid**, 0-1 **no change** heavy 
Orange was 1-2 to **2-2 roundstart**, 1-2 **no change** latejoin, 0-2 to **2-2 lightmid**, 0-1 to **1-2 heavy** 
Red was 2-3 to **2-2 roundstart**, 1-3 to **0-2 latejoin**, 1-2 **no change** lightmid, 1-2 **no change** heavy 
Black was 3-4 to **2-3 roundstart**, 2-3 to **1-2 latejoin**, 1-2 to **1-1 lightmid**, 2-4 **no change** heavy
**This is not the one we care about.**

### Number of Rulesets for current 1.1: fuck it we ball
**There are more rulesets added to each tier, besides bluestar. Bluestar cannot be changed.** 
**Yellow** was 1-1 to **2-3 roundstart**, 0-1 to **2-2 latejoin**, 0-2 to **4-5 light**, 0-1 to **1-2 heavy** 
**Orange** was 1-2 to **2-2 roundstart**, 1-2 to **2-2** latejoin, 0-2 to **3-3 light**, 0-1 to **2-3 heavy** 
**Red** was 2-3 to **2-2 roundstart**, 1-3 to **2-3 latejoin**, 1-2 to **2-3** light, 1-2 **2-3 heavy** 
**Black** was 3-4 to **2-3 roundstart**, 2-3 to **2-3 latejoin**, 1-2 to **1-1 light**, 2-4 to **3-5 heavy**

### **Antagonist weights.**
The minimum requirement bread and butter antagonist are 11 living population. What this means is for the time being traitor is disabled in dead population conditions. **Anything that can do mass killing gimmicks requires 11 living population from default 3**. This will be changed later, just not now.

### **Roundstart weights**- 
Important to know, even a yellow star could have cult, wizard, heretics, which you would have normally never saw. 
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black
Traitor 10 to **16-18-9-11** requires 11 living population 
BB 5 to **14-9-5-2** requires 11 pop
Changeling 3 to **7-9-9-17** requires 15 pop
Cult 0-1-3-3 to **1-3-5-5** requires **23 pop** from 30
Heretic 3 to **6-8-8-13** requires **23 pop** from 30
Revolution 0-1-3-3 to **2-5-7-7** requires **23 pop** from 30
Spies 0-1-3-3 to **11-7-4-10** requires 11 pop
Malf 0-1-3-3 to **1-3-3-5** requires **23 pop** from 30
Wizard 0-0-1-2 to **1-1-3-5** requires **23 pop** from 30
Total weights 21-25-33-33 to **60-66-56-80**


### Latejoining weights
Latejoining has been pushed back actual late round.
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black
Traitor 10 to **10-14-10-10** requires 11 pop
Changeling 3 to **3-5-5-10** requires 15 pop
revolution 1 to **0-1-1-2** requires 30 pop
Heretic doesn't work at the moment, set to 0
Total weights 17 to **13-20-16-22**

### **Light Midrounds weights**
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black
Traitor 10 to **17-14-13-13** requires 11 population
Obsessed 5-5-3-1 to **8-8-5-5** requires 5 pop
Rev ghost 5 to **5-5-3-2** requires 13 pop
Paraclone 5 to **8-8-10-10** requires 8 pop
light pirates 3 to **2-3-3-5** requires 15 pop
Nightmare 5 to **3-3-5-7** requires 15 pop
Changeling 5 to **8-9-9-13** requires 15 pop
Abductors 5 to **6-6-6-5** requires 20 pop
Fugitives 3 to **8-8-5-5** requires 15 pop
Voidwalker 5 to **3-5-5-10** requires 30 pop
Total weights 51-51-49-47 to **65-63-60-69**

### **Heavy Midrounds weights**
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black
Heavy pirate 3 **no change**, requires 25 pop
Wizard 0-0-1-2 to **1-1-3-5** requires 25 pop
Spiders 0-0-1-2 to **10-5-5-5** requires 30 pop
Nukeops 0-1-3-3 to **2-1-2-5** requires 30 pop
Blob 0-1-3-3 to **2-2-3-3** requires 30 pop
blob infect 0-1-3-3 to **4-5-5-5** requires 30 pop
Xeno 0-1-5-5 to **10-5-8-5** requires 30 pop
Dragon 0-3-5-5 to **5** requires 30 pop
Ninja 0-0-1-2 to **10-10-5-5** requires 30 pop
Malf 0-1-3-3 to **5-2-5-5** requires 30 pop
Mass ling 0-3-4-5 to **1-5-5-6** requires 25 pop
Mass traitor 0-3-8-10 to **7-11-10-7** requires 18 pop
Total weight 3-11-28-31 to **60-55-59-59**


### Timing of midround rulesets
Now timing of each ruleset latejoin, lightmid, heavy for when they start and then average time spent injecting and when they should all be done with. Dynamic must clear all light midrounds before injecting heavy into it

### Latejoining timers big change
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black
**Latejoin timer** used to start 5-5-5-5 minutes into a shift. **This now starts at 65-65-65-55**. Cycle used to end between 0-25 minutes. **This cycle now is 65-85 minutes.** 
What this means is latejoining has been pushed back to provide a second wind for any antagonist joining and hopefully end the round. This part of the reason pushing back and then also making this fair about the decrease of antagonist is splitting off each of what the weights were, back into their respective roundstart, light midrounds and heavy midrounds, rounding up. The weights of traitor, sub-traitors, changlings, heretics and revolutions increased across the board.

### Light midrounds timers
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black
**Light midround timer** starts at 30-30-30-20 minutes into a shift. **This now starts at 25-25-25-20 minutes**. 
The important figure is the middle number, that is when all the rolls should conclude and then move on.
Example: Light yellow star. 55-68.75-85 minutes, So dynamic will run 3 or 4 times in some set RNG timer and the end result to move to the next tier can be at earliest 55 minutes to maximum of 85 minutes.

Dynamic cycles used to end this segement was between and now currently
Yellow 30-30-50 minutes, to **55-68.75-85 minutes**    Ruleset injection 0-2 to **3-4**
Orange 30-30-50 minutes, to **45-55-65 minutes**       Ruleset injection 0-2 to **2-2**
Red 30-37.5-50 minutes, **35-43.75-55 minutes**          Ruleset injection **1-2**
Black 20-27.5-40 minutes, **25-25-25 minutes**            Ruleset injection 1-2 to **1-1**

### Heavy midrounds timers
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black
**Heavy midround timer** starts at 60-60-60-30 minutes into a shift **This now starts at 50-45-45-30 minutes**
Example: heavy yellow star. 60-67.5-60 minutes, So dynamic will run 1 or 2 times in some set RNG timer and the end result should finish up at the earliest 50 minutes to maximum of 70 minutes.

Dynamic cycles used to end this segement was between and now currently
Yellow 60-67.5-60 minutes to **50-76.25-70 minutes** Ruleset injection 0-1 to **1-2**
Orange 60-67.5-60 minutes to **55-82.5-85 minutes** Ruleset injection 0-1 to **2-3**
Red 60-82.5-80 minutes to **55-82.5-85 minutes**       Ruleset injection 1-2 to **2-3**
Black 40-75-90 minutes to **50-80-90 minutes**          Ruleset injection 2-4 to **3-5**
Important understanding, why these numbers went up. there are more rulesets that dynamic must go through and must complete every single injection. **There must be 0 light round rulesets remaining to get into heavy ruleset rolls.**

Fuck it we ball.