### PR TITLE
Manuel dynamic 1.2: fuck it we ball

### DIFF
--- a/manuel/dynamic.toml
+++ b/manuel/dynamic.toml
@@ -153,7 +153,7 @@ ruleset_type_settings.latejoin.time_threshold = 55
 ruleset_type_settings.latejoin.execution_cooldown_low = 5
 ruleset_type_settings.latejoin.execution_cooldown_high = 10
 
-
+//latejoining starts at 65 minutes.
 ["Latejoin Traitor"]
 weight.1 = 10
 weight.2 = 14
@@ -161,14 +161,6 @@ weight.3 = 10
 weight.4 = 10
 min_pop = 11
 repeatable_weight_decrease = 5
-
-["Latejoin Heretic"]
-weight.1 = 0
-weight.2 = 0
-weight.3 = 0
-weight.4 = 0
-min_pop = 30
-repeatable_weight_decrease = 4
 
 ["Latejoin Changeling"]
 weight.1 = 3
@@ -186,211 +178,39 @@ weight.4 = 2
 min_pop = 30
 repeatable = 0
 
-["Spiders"]
-weight.1 = 10
-weight.2 = 5
-weight.3 = 5
-weight.4 = 5
-min_pop = 30
-repeatable_weight_decrease = 4
+//roundstart rulesets
+//the clarity order is min_pop requirement
+["Roundstart Traitor"]
+weight.1 = 25
+weight.2 = 28
+weight.3 = 13
+weight.4 = 21
+min_pop = 11
+repeatable_weight_decrease = 6
 
-["Light Pirates"]
-weight.1 = 2
-weight.2 = 3
-weight.3 = 3
-weight.4 = 5
-min_pop = 15
-repeatable_weight_decrease = 2
-
-["Heavy Pirates"]
-weight.1 = 3
-weight.2 = 3
-weight.3 = 3
-weight.4 = 3
-min_pop = 25
-repeatable_weight_decrease = 4
-
-["Midround Wizard"]
-weight.1 = 1
-weight.2 = 1
-weight.3 = 3
-weight.4 = 5
-min_pop = 30
-repeatable_weight_decrease = 2
-
-["Midround Nukeops"]
-weight.1 = 2
-weight.2 = 1
-weight.3 = 2
-weight.4 = 5
-min_pop = 30
-repeatable = 0
-
-["Midround Clownops"]
-weight = 0
-min_pop = 30
-repeatable = 0
-
-["Blob"]
-weight.1 = 2
-weight.2 = 2
-weight.3 = 3
-weight.4 = 3
-min_pop = 30
-repeatable_weight_decrease = 3
-
-["Xenomorph"]
-weight.1 = 10
-weight.2 = 5
-weight.3 = 8
-weight.4 = 5
-min_pop = 30
-repeatable_weight_decrease = 4
-
-["Nightmare"]
-weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.4 = 7
-min_pop = 15
-repeatable_weight_decrease = 5
-
-["Space Dragon"]
-weight.1 = 5
-weight.2 = 5
-weight.3 = 5
-weight.4 = 5
-min_pop = 30
-repeatable_weight_decrease = 4
-
-["Abductors"]
-weight.1 = 6
-weight.2 = 6
+["Roundstart Spies"]
+weight.1 = 15
+weight.2 = 11
 weight.3 = 6
-weight.4 = 5
-min_pop = 20
-repeatable_weight_decrease = 3
+weight.4 = 12
+min_pop = 11
+repeatable_weight_decrease = 4
 
-["Space Ninja"]
-weight.1 = 10
-weight.2 = 10
-weight.3 = 5
-weight.4 = 5
-min_pop = 30
-repeatable_weight_decrease = 5
+["Roundstart Blood Brothers"]
+weight.1 = 19
+weight.2 = 15
+weight.3 = 7
+weight.4 = 4
+min_pop = 11
+repeatable_weight_decrease = 6
 
-["Revenant"]
-weight.1 = 5
-weight.2 = 3
-weight.3 = 3
-weight.4 = 2
-min_pop = 10
-repeatable = 0
-
-["Midround Changeling"]
-weight.1 = 8
+["Roundstart Changeling"]
+weight.1 = 7
 weight.2 = 9
 weight.3 = 9
-weight.4 = 13
+weight.4 = 17
 min_pop = 15
-repeatable_weight_decrease = 4
-
-["Midround Mass Changelings"]
-weight.1 = 1
-weight.2 = 5
-weight.3 = 5
-weight.4 = 6
-min_pop = 25
-blacklisted_roles = []
-repeatable_weight_decrease = 4
-repeatable = 1
-min_antag_cap = 2
-max_antag_cap = 3
-
-["Paradox Clone"]
-weight.1 = 8
-weight.2 = 8
-weight.3 = 10
-weight.4 = 10
-min_pop = 10
-repeatable_weight_decrease = 4
-
-["Voidwalker"]
-weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.4 = 10
-min_pop = 30
 repeatable_weight_decrease = 3
-
-["Fugitives"]
-weight.1 = 8
-weight.2 = 8
-weight.3 = 5
-weight.4 = 5
-min_pop = 20
-repeatable = 0
-
-["Morph"]
-weight = 0
-min_pop = 0
-repeatable_weight_decrease = 2
-
-["Slaughter Demon"]
-weight = 0
-min_pop = 20
-repeatable_weight_decrease = 2
-
-["Midround Traitor"]
-weight.1 = 17
-weight.2 = 14
-weight.3 = 13
-weight.4 = 13
-min_pop = 11
-repeatable_weight_decrease = 4
-
-["Midround Mass Traitors"]
-weight.1 = 7
-weight.2 = 11
-weight.3 = 10
-weight.4 = 7
-min_pop = 15
-repeatable_weight_decrease = 8
-repeatable = 1
-min_antag_cap = 2
-max_antag_cap = 3
-
-["Midround Malfunctioning AI"]
-weight.1 = 5
-weight.2 = 2
-weight.3 = 5
-weight.4 = 5
-min_pop = 30
-repeatable = 0
-
-["Blob Infection"]
-weight.1 = 4
-weight.2 = 2
-weight.3 = 5
-weight.4 = 5
-min_pop = 30
-repeatable_weight_decrease = 4
-
-["Midround Obsessed"]
-weight.1 = 8
-weight.2 = 8
-weight.3 = 5
-weight.4 = 5
-min_pop = 5
-repeatable_weight_decrease = 4
-
-["Roundstart Traitor"]
-weight.1 = 16
-weight.2 = 18
-weight.3 = 9
-weight.4 = 11
-min_pop = 11
-repeatable_weight_decrease = 4
 
 ["Roundstart Malfunctioning AI"]
 weight.1 = 1
@@ -400,21 +220,13 @@ weight.4 = 5
 min_pop = 23
 repeatable = 0
 
-["Roundstart Blood Brothers"]
-weight.1 = 14
-weight.2 = 9
-weight.3 = 5
-weight.4 = 2
-min_pop = 11
-repeatable_weight_decrease = 4
-
-["Roundstart Changeling"]
-weight.1 = 7
-weight.2 = 9
-weight.3 = 9
-weight.4 = 17
-min_pop = 15
-repeatable_weight_decrease = 3
+["Roundstart Blood Worm"]
+weight.1 = 3
+weight.2 = 4
+weight.3 = 4
+weight.4 = 6
+min_pop = 23
+repeatable = 0
 
 ["Roundstart Heretics"]
 weight.1 = 6
@@ -448,11 +260,6 @@ weight.4 = 5
 min_pop = 23
 repeatable = 0
 
-["Roundstart Clownops"]
-weight = 0
-min_pop = 30
-repeatable = 0
-
 ["Roundstart Revolution"]
 weight.1 = 2
 weight.2 = 5
@@ -461,17 +268,206 @@ weight.4 = 7
 min_pop = 23
 repeatable = 0
 
-["Roundstart Spies"]
-weight.1 = 11
-weight.2 = 7
-weight.3 = 4
+//lightmid rulesets
+//the clarity order is min_pop requirement
+["Midround Obsessed"]
+weight.1 = 8
+weight.2 = 8
+weight.3 = 5
+weight.4 = 5
+min_pop = 5
+repeatable_weight_decrease = 4
+
+["Revenant"]
+weight.1 = 5
+weight.2 = 3
+weight.3 = 3
+weight.4 = 2
+min_pop = 10
+repeatable = 0
+
+["Paradox Clone"]
+weight.1 = 8
+weight.2 = 8
+weight.3 = 10
 weight.4 = 10
+min_pop = 10
+repeatable_weight_decrease = 4
+
+["Midround Traitor"]
+weight.1 = 17
+weight.2 = 14
+weight.3 = 13
+weight.4 = 13
 min_pop = 11
 repeatable_weight_decrease = 4
 
-["Extended"]
+["Midround Changeling"]
+weight.1 = 8
+weight.2 = 9
+weight.3 = 9
+weight.4 = 13
+min_pop = 15
+repeatable_weight_decrease = 4
+
+["Light Pirates"]
+weight.1 = 2
+weight.2 = 3
+weight.3 = 3
+weight.4 = 5
+min_pop = 15
+repeatable_weight_decrease = 2
+
+["Nightmare"]
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 7
+min_pop = 15
+repeatable_weight_decrease = 5
+
+["Abductors"]
+weight.1 = 5
+weight.2 = 5
+weight.3 = 5
+weight.4 = 4
+min_pop = 20
+repeatable_weight_decrease = 3
+
+["Fugitives"]
+weight.1 = 9
+weight.2 = 9
+weight.3 = 6
+weight.4 = 6
+min_pop = 20
+repeatable = 0
+
+["Voidwalker"]
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
+min_pop = 30
+repeatable_weight_decrease = 3
+
+["Midround Blood Worm"]
+weight.1 = 3
+weight.2 = 3
+weight.3 = 4
+weight.4 = 6
+min_pop = 30
+repeatable = 0
+
+//heavymid rulesets
+//The reason of why midround mass rulesets exist is because the heavier threats were not being taken.
+["Midround Mass Traitors"]
+weight.1 = 7
+weight.2 = 11
+weight.3 = 10
+weight.4 = 7
+min_pop = 15
+repeatable_weight_decrease = 8
+repeatable = 1
+min_antag_cap = 2
+max_antag_cap = 3
+
+["Midround Mass Changelings"]
+weight.1 = 1
+weight.2 = 5
+weight.3 = 5
+weight.4 = 6
+min_pop = 25
+repeatable_weight_decrease = 4
+repeatable = 1
+min_antag_cap = 2
+max_antag_cap = 3
+
+["Heavy Pirates"]
+weight.1 = 3
+weight.2 = 3
+weight.3 = 3
+weight.4 = 3
+min_pop = 25
+repeatable_weight_decrease = 4
+
+["Spiders"]
+weight.1 = 10
+weight.2 = 5
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Midround Wizard"]
+weight.1 = 1
+weight.2 = 1
+weight.3 = 3
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 2
+
+["Midround Nukeops"]
+weight.1 = 2
+weight.2 = 1
+weight.3 = 2
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Blob"]
+weight.1 = 2
+weight.2 = 2
+weight.3 = 3
+weight.4 = 3
+min_pop = 30
+repeatable_weight_decrease = 3
+
+["Xenomorph"]
+weight.1 = 10
+weight.2 = 5
+weight.3 = 8
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Space Dragon"]
+weight.1 = 5
+weight.2 = 5
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Space Ninja"]
+weight.1 = 10
+weight.2 = 10
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 5
+
+["Midround Malfunctioning AI"]
+weight.1 = 5
+weight.2 = 2
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Blob Infection"]
+weight.1 = 4
+weight.2 = 2
+weight.3 = 5
+weight.4 = 5
+min_pop = 30
+repeatable_weight_decrease = 4
+
+//unused roundstarts
+//Important to note that clownops is bugged, doesn't work even if you try to force the rulesets. The only way around this is manually spawning clownops and loading infiltrator ship.
+["Roundstart Clownops"]
 weight = 0
-min_pop = 0
+min_pop = 30
+repeatable = 0
 
 ["Meteor"]
 weight = 0
@@ -480,3 +476,35 @@ min_pop = 0
 ["Nations"]
 weight = 0
 min_pop = 0
+
+["Extended"]
+weight = 0
+min_pop = 0
+
+//unused lightround.
+["Morph"]
+weight = 0
+min_pop = 0
+repeatable_weight_decrease = 2
+
+//unused latejoin. important to note this was removed, this must be added back in for this ruleset to function.
+["Latejoin Heretic"]
+weight.1 = 0
+weight.2 = 0
+weight.3 = 0
+weight.4 = 0
+min_pop = 30
+repeatable_weight_decrease = 4
+
+//unusued heavyround rulesets
+//clownops doesn't load in at all.
+//slaughter demons delete mobs they consume.
+["Midround Clownops"]
+weight = 0
+min_pop = 30
+repeatable = 0
+
+["Slaughter Demon"]
+weight = 0
+min_pop = 20
+repeatable_weight_decrease = 2


### PR DESCRIPTION
**Tldr. Human antagonist rulesets has been increased while non-human antagonist rulesets have been decreased by the addition of this change.  Blood worm has been added to the mix and increased from code default slightly.**

//comments added to clarify what the reader is looking for and how things are listed.
//also pushed unused rulesets to the bottom so that they are no longer within the core list and listed the reasons of why they aren't in.

### **Actual Changes:**

### **Antagonist weights.**
The minimum requirement bread and butter antagonist are 11 living population. What this means is for the time being traitor is disabled in dead population conditions. Anything that can do mass killing gimmicks requires 11 living population from default 3. This will be changed later, just not now.
12-18-2025 edit: looks like there is less of an issue for low pop stuff from tickets and watching. I will bring 11 living population down after this. This will be soon.

### **Roundstart weights-**
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black orbits
**Traitor** 16-18-9-11 to **25-28-13-21**
**BB** 14-9-5-2 to **19-15-7-4**
**Spies** 11-7-4-10 to **15-11-6-12**
**Rstart Bworm** 2-2-2-2 to **3-4-4-6 requires 23 living population**
**Total weights** 60-66-56-80 to **81-90-68-100**

What this means:
**Roundstart Traitors** is bumped up 26%-26%-16%-13%, average being 21% of all rolls to **31%-31%-19%-21%, average being 26% of all rolls.**
**BB** is bumped up 23%-13%-9%-2%, average being 11% of all rolls to **23%-17%-10%-4%, average being 14% of all rolls.**
**Spies** is bumped up 18%-10%-7%-12%, average being 10% of all rolls to **19%-12%-9%-12%, average being 12% of all rolls.**
**roundstart Bworm** is bumped up 3%-3%-2%-3%, average being 3% of all rolls to **4%-6%-6%-5%, average being 6% of all rolls.**

### **Light Midrounds weights**
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black orbits
**Traitor** 17-14-13-13 to **22-18-18-18**
**Abductors** 6-6-6-5 to **5-5-5-4**
**Fugitives** 8-8-5-5 to **9-9-6-6**
**midround Bworm** 2-2-2-2 to **3-3-4-6 requires 30 living population**
**Total weights** 65-63-60-69 to **76-76-73-86**

What this means:
Light traitor is bumped up from 25%-20%-20%-17%, average being 20% of all rolls to **29%-24%-25%-21%, average being 24% of all rolls.**
Abductors is bumped down from 9%-8%-9%-6%, average being 8% of all rolls to **7%-7%-7%-5%, average being 6% of all rolls.**
fugitives is bumped up from 11%-11%-8%-6%, average being 10% of all rolls to **12%-12%-8%-7%, average being 10% of all rolls.**
Bworm is bumped up from 3%-3%-3%-3%, average being 3% of all rolls to **4%-4%-5%-7%, average being 5% of all rolls**

### **Heavy Midrounds weights**
a(x)-b(x)-c(x)-d(x) means yellow-orange-red-black orbits
**Mass traitor** 7-11-10-7 to **8-13-13-8**
**Total weight** 60-55-59-59 to **61-57-62-60**

What this means:
Mass tratior is bumped up from 12%-20%-17%-12%, average being 17% of all rolls to **13%-23%-21%-13%, average being 20% of all rolls.**
