### PR TITLE
Terry dynamic crunch 1.0

### DIFF
--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -345,6 +345,14 @@ weight.4 = 18
 min_pop = 3
 repeatable_weight_decrease = 4
 
+["Midround Blood Worm"]
+weight.1 = 3
+weight.2 = 3
+weight.3 = 4
+weight.4 = 6
+min_pop = 30
+repeatable = 0
+
 //Heavy midround rulesets
 ["Spiders"]
 weight.1 = 10
@@ -425,6 +433,28 @@ weight.3 = 4
 weight.4 = 4
 min_pop = 30
 repeatable_weight_decrease = 3
+
+["Midround Mass Changelings"]
+weight.1 = 1
+weight.2 = 5
+weight.3 = 5
+weight.4 = 6
+min_pop = 25
+repeatable_weight_decrease = 4
+repeatable = 1
+min_antag_cap = 2
+max_antag_cap = 3
+
+["Midround Mass Traitors"]
+weight.1 = 8
+weight.2 = 13
+weight.3 = 13
+weight.4 = 8
+min_pop = 15
+repeatable_weight_decrease = 8
+repeatable = 1
+min_antag_cap = 2
+max_antag_cap = 3
 
 //unused roundstart modes
 ["Extended"]

--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -1,5 +1,5 @@
 ["Greenshift"]
-weight = 0
+weight = 2
 name = "Blue Star"
 min_pop = 0
 advisory_report = "Advisory Level: Advisory Level: <b>Blue Star</b></center><BR>Your sector's advisory level is Blue Star. Surveillance shows low levels of enemy activity in the sector.  We advise a normal working routine with increased vigilance."
@@ -32,116 +32,116 @@ ruleset_type_settings.latejoin.execution_cooldown_high = 30
 ["Low Chaos"]
 name = "Yellow Star"
 min_pop = 0
-weight = 10
+weight = 23
 advisory_report = "Advisory Level: <b>Yellow Star</b></center><BR>Your sector's advisory level is Yellow Star. Surveillance shows a credible risk of enemy attack against our assets in the Spinward Sector. We advise a heightened level of security alongside maintaining vigilance against potential threats."
 ruleset_type_settings.roundstart.low = 2
-ruleset_type_settings.roundstart.high = 2
-ruleset_type_settings.roundstart.half_range_pop_threshold = 15
-ruleset_type_settings.roundstart.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.low = 1
-ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.roundstart.high = 4
+ruleset_type_settings.roundstart.half_range_pop_threshold = 22
+ruleset_type_settings.roundstart.full_range_pop_threshold = 40
+ruleset_type_settings.light_midround.low = 3
+ruleset_type_settings.light_midround.high = 4
 ruleset_type_settings.light_midround.half_range_pop_threshold = 15
-ruleset_type_settings.light_midround.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.time_threshold = 25
-ruleset_type_settings.light_midround.execution_cooldown_low = 15
-ruleset_type_settings.light_midround.execution_cooldown_high = 25
+ruleset_type_settings.light_midround.full_range_pop_threshold = 30
+ruleset_type_settings.light_midround.time_threshold = 28
+ruleset_type_settings.light_midround.execution_cooldown_low = 8
+ruleset_type_settings.light_midround.execution_cooldown_high = 16
 ruleset_type_settings.heavy_midround.low = 0
-ruleset_type_settings.heavy_midround.high = 0
-ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
-ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
+ruleset_type_settings.heavy_midround.high = 1
+ruleset_type_settings.heavy_midround.half_range_pop_threshold = 22
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 30
 ruleset_type_settings.heavy_midround.time_threshold = 50
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 0
-ruleset_type_settings.latejoin.high = 1
+ruleset_type_settings.latejoin.low = 1
+ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 15
-ruleset_type_settings.latejoin.full_range_pop_threshold = 25
-ruleset_type_settings.latejoin.time_threshold = 15
+ruleset_type_settings.latejoin.full_range_pop_threshold = 30
+ruleset_type_settings.latejoin.time_threshold = 55
 ruleset_type_settings.latejoin.execution_cooldown_low = 15
 ruleset_type_settings.latejoin.execution_cooldown_high = 30
 
 ["Low-Medium Chaos"]
 name = "Orange Star"
-min_pop = 10
-weight = 45
+min_pop = 18
+weight = 38
 advisory_report = "Advisory Level: <b>Orange Star</b></center><BR>Your sector's advisory level is Orange Star. The Department of Intelligence has decrypted Cybersun communications suggesting a high likelihood of attacks on Nanotrasen assets within the Spinward Sector. Stations in the region are advised to remain highly vigilant for signs of enemy activity and to be on high alert."
-ruleset_type_settings.roundstart.low = 2
-ruleset_type_settings.roundstart.high = 4
-ruleset_type_settings.roundstart.half_range_pop_threshold = 15
-ruleset_type_settings.roundstart.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.low = 1
-ruleset_type_settings.light_midround.high = 2
+ruleset_type_settings.roundstart.low = 3
+ruleset_type_settings.roundstart.high = 5
+ruleset_type_settings.roundstart.half_range_pop_threshold = 22
+ruleset_type_settings.roundstart.full_range_pop_threshold = 35
+ruleset_type_settings.light_midround.low = 2
+ruleset_type_settings.light_midround.high = 3
 ruleset_type_settings.light_midround.half_range_pop_threshold = 15
-ruleset_type_settings.light_midround.full_range_pop_threshold = 25
+ruleset_type_settings.light_midround.full_range_pop_threshold = 35
 ruleset_type_settings.light_midround.time_threshold = 30
 ruleset_type_settings.light_midround.execution_cooldown_low = 10
 ruleset_type_settings.light_midround.execution_cooldown_high = 15
 ruleset_type_settings.heavy_midround.low = 1
-ruleset_type_settings.heavy_midround.high = 2
+ruleset_type_settings.heavy_midround.high = 3
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
-ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 35
 ruleset_type_settings.heavy_midround.time_threshold = 40
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 0
+ruleset_type_settings.latejoin.low = 2
 ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 15
 ruleset_type_settings.latejoin.full_range_pop_threshold = 25
-ruleset_type_settings.latejoin.time_threshold = 10
+ruleset_type_settings.latejoin.time_threshold = 55
 ruleset_type_settings.latejoin.execution_cooldown_low = 10
 ruleset_type_settings.latejoin.execution_cooldown_high = 20
 
 ["Medium-High Chaos"]
 name = "Red Star"
-min_pop = 20
-weight = 35
+min_pop = 27
+weight = 23
 advisory_report = "Advisory Level: <b>Red Star</b></center><BR>Your sector's advisory level is Red Star. Multiple communications signals in your sector have been intercepted, with partial success in decryption. Analysis combined with information passed to us by GDI suggests a high amount of enemy activity in the sector, indicative of impending attacks. Remain on high alert and vigilant against any potential threats."
-ruleset_type_settings.roundstart.low = 2
-ruleset_type_settings.roundstart.high = 4
-ruleset_type_settings.roundstart.half_range_pop_threshold = 15
-ruleset_type_settings.roundstart.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.low = 1
-ruleset_type_settings.light_midround.high = 1
-ruleset_type_settings.light_midround.half_range_pop_threshold = 15
-ruleset_type_settings.light_midround.full_range_pop_threshold = 25
-ruleset_type_settings.light_midround.time_threshold = 25
-ruleset_type_settings.light_midround.execution_cooldown_low = 10
-ruleset_type_settings.light_midround.execution_cooldown_high = 15
-ruleset_type_settings.heavy_midround.low = 1
-ruleset_type_settings.heavy_midround.high = 2
-ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
-ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
+ruleset_type_settings.roundstart.low = 3
+ruleset_type_settings.roundstart.high = 5
+ruleset_type_settings.roundstart.half_range_pop_threshold = 25
+ruleset_type_settings.roundstart.full_range_pop_threshold = 35
+ruleset_type_settings.light_midround.low = 2
+ruleset_type_settings.light_midround.high = 3
+ruleset_type_settings.light_midround.half_range_pop_threshold = 25
+ruleset_type_settings.light_midround.full_range_pop_threshold = 35
+ruleset_type_settings.light_midround.time_threshold = 30
+ruleset_type_settings.light_midround.execution_cooldown_low = 8
+ruleset_type_settings.light_midround.execution_cooldown_high = 16
+ruleset_type_settings.heavy_midround.low = 2
+ruleset_type_settings.heavy_midround.high = 3
+ruleset_type_settings.heavy_midround.half_range_pop_threshold = 20
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 35
 ruleset_type_settings.heavy_midround.time_threshold = 40
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
-ruleset_type_settings.latejoin.low = 0
+ruleset_type_settings.latejoin.low = 1
 ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 15
 ruleset_type_settings.latejoin.full_range_pop_threshold = 25
-ruleset_type_settings.latejoin.time_threshold = 5
+ruleset_type_settings.latejoin.time_threshold = 45
 ruleset_type_settings.latejoin.execution_cooldown_low = 5
 ruleset_type_settings.latejoin.execution_cooldown_high = 15
 
 ["High Chaos"]
 name = "Black Orbit"
-min_pop = 30
-weight = 10
+min_pop = 35
+weight = 14
 advisory_report = "Advisory Level: <b>Black Orbit</b></center><BR>Your sector's advisory level is Black Orbit. Multiple jamming signals in your region limit intelligence and render traditional classifications inapplicable.  Analysis suggests a mask to cover a large scale mobilisation in the region, or multiple significant independent threats.  Credible information passed to us by GDI suggests that the Syndicate is preparing to mount a major concerted offensive on Nanotrasen assets in the Spinward Sector to cripple our foothold there. All stations should remain on high alert and prepared to defend themselves."
-ruleset_type_settings.roundstart.low = 2
-ruleset_type_settings.roundstart.high = 3
-ruleset_type_settings.roundstart.half_range_pop_threshold = 15
-ruleset_type_settings.roundstart.full_range_pop_threshold = 25
+ruleset_type_settings.roundstart.low = 3
+ruleset_type_settings.roundstart.high = 5
+ruleset_type_settings.roundstart.half_range_pop_threshold = 25
+ruleset_type_settings.roundstart.full_range_pop_threshold = 40
 ruleset_type_settings.light_midround.low = 1
 ruleset_type_settings.light_midround.high = 1
-ruleset_type_settings.light_midround.half_range_pop_threshold = 15
-ruleset_type_settings.light_midround.full_range_pop_threshold = 25
+ruleset_type_settings.light_midround.half_range_pop_threshold = 25
+ruleset_type_settings.light_midround.full_range_pop_threshold = 40
 ruleset_type_settings.light_midround.time_threshold = 15
 ruleset_type_settings.light_midround.execution_cooldown_low = 7
 ruleset_type_settings.light_midround.execution_cooldown_high = 13
 ruleset_type_settings.heavy_midround.low = 5
 ruleset_type_settings.heavy_midround.high = 5
-ruleset_type_settings.heavy_midround.half_range_pop_threshold = 15
-ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
+ruleset_type_settings.heavy_midround.half_range_pop_threshold = 25
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 35
 ruleset_type_settings.heavy_midround.time_threshold = 30
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 10
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
@@ -149,22 +149,14 @@ ruleset_type_settings.latejoin.low = 1
 ruleset_type_settings.latejoin.high = 2
 ruleset_type_settings.latejoin.half_range_pop_threshold = 15
 ruleset_type_settings.latejoin.full_range_pop_threshold = 25
-ruleset_type_settings.latejoin.time_threshold = 5
+ruleset_type_settings.latejoin.time_threshold = 45
 ruleset_type_settings.latejoin.execution_cooldown_low = 5
 ruleset_type_settings.latejoin.execution_cooldown_high = 10
 
-
+//latejoining starts 45 to 65 minutes into a shift.
 ["Latejoin Traitor"]
 weight = 10
 min_pop = 3
-repeatable_weight_decrease = 4
-
-["Latejoin Heretic"]
-weight.1 = 0
-weight.2 = 3
-weight.3 = 5
-weight.4 = 10
-min_pop = 30
 repeatable_weight_decrease = 4
 
 ["Latejoin Changeling"]
@@ -183,21 +175,184 @@ weight.4 = 2
 min_pop = 30
 repeatable = 0
 
+//roundstart rulesets
+["Roundstart Traitor"]
+weight.1 = 25
+weight.2 = 28
+weight.3 = 13
+weight.4 = 21
+min_pop = 3
+repeatable_weight_decrease = 6
+
+["Roundstart Malfunctioning AI"]
+weight.1 = 1
+weight.2 = 3
+weight.3 = 3
+weight.4 = 4
+min_pop = 30
+repeatable = 0
+
+["Roundstart Blood Brothers"]
+weight.1 = 19
+weight.2 = 15
+weight.3 = 7
+weight.4 = 4
+min_pop = 10
+repeatable_weight_decrease = 6
+
+["Roundstart Changeling"]
+weight.1 = 7
+weight.2 = 9
+weight.3 = 9
+weight.4 = 17
+min_pop = 15
+repeatable_weight_decrease = 3
+
+["Roundstart Heretics"]
+weight.1 = 6
+weight.2 = 8
+weight.3 = 8
+weight.4 = 11
+min_pop = 30
+repeatable_weight_decrease = 4
+
+["Roundstart Wizard"]
+weight.1 = 1
+weight.2 = 1
+weight.3 = 3
+weight.4 = 4
+min_pop = 33
+repeatable = 0
+
+["Roundstart Blood Cult"]
+weight.1 = 1
+weight.2 = 3
+weight.3 = 3
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Roundstart Nukeops"]
+weight.1 = 1
+weight.2 = 3
+weight.3 = 3
+weight.4 = 4
+min_pop = 30
+repeatable = 0
+
+["Roundstart Revolution"]
+weight.1 = 1
+weight.2 = 3
+weight.3 = 3
+weight.4 = 5
+min_pop = 30
+repeatable = 0
+
+["Roundstart Spies"]
+weight.1 = 15
+weight.2 = 11
+weight.3 = 6
+weight.4 = 12
+min_pop = 10
+repeatable_weight_decrease = 5
+
+["Nations"]
+weight.1 = 0
+weight.2 = 2
+weight.3 = 0
+weight.4 = 2
+min_pop = 40
+repeatable = 0
+
+//light midround rulesets
+["Midround Obsessed"]
+weight.1 = 8
+weight.2 = 8
+weight.3 = 8
+weight.4 = 8
+min_pop = 5
+repeatable_weight_decrease = 3
+
+["Light Pirates"]
+weight.1 = 6
+weight.2 = 6
+weight.3 = 6
+weight.4 = 6
+min_pop = 15
+repeatable_weight_decrease = 3
+
+["Nightmare"]
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
+min_pop = 15
+repeatable_weight_decrease = 3
+
+["Abductors"]
+weight.1 = 3
+weight.2 = 3
+weight.3 = 3
+weight.4 = 2
+min_pop = 20
+repeatable_weight_decrease = 3
+
+["Revenant"]
+weight.1 = 5
+weight.2 = 5
+weight.3 = 2
+weight.4 = 2
+min_pop = 10
+repeatable = 0
+
+["Midround Changeling"]
+weight.1 = 8
+weight.2 = 9
+weight.3 = 9
+weight.4 = 13
+min_pop = 15
+repeatable_weight_decrease = 3
+
+["Paradox Clone"]
+weight.1 = 8
+weight.2 = 8
+weight.3 = 10
+weight.4 = 10
+min_pop = 10
+repeatable_weight_decrease = 4
+
+["Voidwalker"]
+weight.1 = 3
+weight.2 = 5
+weight.3 = 5
+weight.4 = 10
+min_pop = 30
+repeatable_weight_decrease = 3
+
+["Fugitives"]
+weight.1 = 9
+weight.2 = 9
+weight.3 = 6
+weight.4 = 6
+min_pop = 20
+repeatable = 0
+
+["Midround Traitor"]
+weight.1 = 22
+weight.2 = 18
+weight.3 = 18
+weight.4 = 18
+min_pop = 3
+repeatable_weight_decrease = 4
+
+//Heavy midround rulesets
 ["Spiders"]
 weight.1 = 10
-weight.2 = 10
+weight.2 = 5
 weight.3 = 5
 weight.4 = 5
 min_pop = 30
 repeatable_weight_decrease = 4
-
-["Light Pirates"]
-weight.1 = 2
-weight.2 = 3
-weight.3 = 3
-weight.4 = 5
-min_pop = 15
-repeatable_weight_decrease = 2
 
 ["Heavy Pirates"]
 weight.1 = 5
@@ -209,129 +364,50 @@ repeatable_weight_decrease = 4
 
 ["Midround Wizard"]
 weight.1 = 1
-weight.2 = 0
-weight.3 = 1
+weight.2 = 1
+weight.3 = 3
 weight.4 = 5
 min_pop = 30
 repeatable_weight_decrease = 2
 
 ["Midround Nukeops"]
-weight.1 = 2
+weight.1 = 1
 weight.2 = 1
-weight.3 = 2
+weight.3 = 5
 weight.4 = 5
 min_pop = 30
 repeatable = 0
 
-["Midround Clownops"]
-weight = 0
-min_pop = 30
-repeatable = 0
-
 ["Blob"]
-weight.1 = 2
-weight.2 = 2
-weight.3 = 3
-weight.4 = 3
+weight.1 = 3
+weight.2 = 3
+weight.3 = 4
+weight.4 = 4
 min_pop = 30
 repeatable_weight_decrease = 3
 
 ["Xenomorph"]
 weight.1 = 10
 weight.2 = 5
-weight.3 = 10
+weight.3 = 8
 weight.4 = 5
 min_pop = 30
 repeatable_weight_decrease = 4
-
-["Nightmare"]
-weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.4 = 10
-min_pop = 15
-repeatable_weight_decrease = 3
 
 ["Space Dragon"]
-weight.1 = 10
+weight.1 = 5
 weight.2 = 5
-weight.3 = 10
+weight.3 = 6
 weight.4 = 5
 min_pop = 30
 repeatable_weight_decrease = 4
-
-["Abductors"]
-weight.1 = 5
-weight.2 = 3
-weight.3 = 3
-weight.4 = 1
-min_pop = 20
-repeatable_weight_decrease = 3
 
 ["Space Ninja"]
-weight.1 = 10
-weight.2 = 5
-weight.3 = 10
-weight.4 = 5
-min_pop = 30
-repeatable_weight_decrease = 4
-
-["Revenant"]
-weight.1 = 5
-weight.2 = 3
-weight.3 = 3
-weight.4 = 1
-min_pop = 10
-repeatable = 0
-
-["Midround Changeling"]
-weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.10 = 10
-min_pop = 15
-repeatable_weight_decrease = 3
-
-["Paradox Clone"]
-weight.1 = 5
-weight.2 = 3
-weight.3 = 1
-weight.4 = 0
-min_pop = 10
-repeatable_weight_decrease = 3
-
-["Voidwalker"]
-weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.4 = 10
-min_pop = 30
-repeatable_weight_decrease = 3
-
-["Fugitives"]
-weight.1 = 3
-weight.2 = 3
-weight.3 = 1
-weight.4 = 0
-min_pop = 20
-repeatable = 0
-
-["Morph"]
-weight = 0
-min_pop = 0
-repeatable_weight_decrease = 2
-
-["Slaughter Demon"]
-weight = 0
-min_pop = 20
-repeatable_weight_decrease = 2
-
-["Midround Traitor"]
 weight.1 = 10
 weight.2 = 10
 weight.3 = 5
 weight.4 = 5
-min_pop = 3
+min_pop = 30
 repeatable_weight_decrease = 4
 
 ["Midround Malfunctioning AI"]
@@ -343,106 +419,14 @@ min_pop = 30
 repeatable = 0
 
 ["Blob Infection"]
-weight.1 = 2
-weight.2 = 2
-weight.3 = 3
-weight.4 = 3
-min_pop = 30
-repeatable_weight_decrease = 3
-
-["Midround Obsessed"]
-weight.1 = 5
-weight.2 = 3
-weight.3 = 1
-weight.4 = 0
-min_pop = 5
-repeatable_weight_decrease = 3
-
-["Roundstart Traitor"]
-weight.1 = 10
-weight.2 = 10
-weight.3 = 5
-weight.4 = 10
-min_pop = 3
-repeatable_weight_decrease = 4
-
-["Roundstart Malfunctioning AI"]
-weight.1 = 0
-weight.2 = 0
-weight.3 = 3
-weight.4 = 5
-min_pop = 30
-repeatable = 0
-
-["Roundstart Blood Brothers"]
-weight.1 = 10
-weight.2 = 5
-weight.3 = 3
-weight.4 = 3
-min_pop = 10
-repeatable_weight_decrease = 4
-
-["Roundstart Changeling"]
 weight.1 = 3
-weight.2 = 5
-weight.3 = 5
-weight.4 = 10
-min_pop = 15
-repeatable_weight_decrease = 3
-
-["Roundstart Heretics"]
-weight.1 = 0
-weight.2 = 3
-weight.3 = 5
-weight.4 = 10
+weight.2 = 4
+weight.3 = 4
+weight.4 = 4
 min_pop = 30
 repeatable_weight_decrease = 3
 
-["Roundstart Wizard"]
-weight.1 = 0
-weight.2 = 0
-weight.3 = 3
-weight.4 = 5
-min_pop = 30
-repeatable = 0
-
-["Roundstart Blood Cult"]
-weight.1 = 0
-weight.2 = 0
-weight.3 = 3
-weight.4 = 5
-min_pop = 30
-repeatable = 0
-
-["Roundstart Nukeops"]
-weight.1 = 0
-weight.2 = 0
-weight.3 = 3
-weight.4 = 5
-min_pop = 30
-repeatable = 0
-
-["Roundstart Clownops"]
-weight = 0
-min_pop = 30
-repeatable = 0
-
-["Roundstart Revolution"]
-weight.1 = 0
-weight.2 = 0
-weight.3 = 3
-weight.4 = 5
-min_pop = 30
-repeatable = 0
-
-["Roundstart Spies"]
-weight.1 = 10
-weight.2 = 5
-weight.3 = 3
-weight.4 = 3
-min_pop = 10
-repeatable_weight_decrease = 4
-
+//unused roundstart modes
 ["Extended"]
 weight = 0
 min_pop = 0
@@ -451,6 +435,35 @@ min_pop = 0
 weight = 0
 min_pop = 0
 
-["Nations"]
+//this latejoin ruleset has been deleted, so if you want this back in, the fix is through the codebase.
+["Latejoin Heretic"]
+weight.1 = 0
+weight.2 = 3
+weight.3 = 5
+weight.4 = 10
+min_pop = 30
+repeatable_weight_decrease = 4
+
+//unused midrounds
+//morph eats armory too often and slaughter demon deletes folks.
+["Morph"]
 weight = 0
 min_pop = 0
+repeatable_weight_decrease = 2
+
+["Slaughter Demon"]
+weight = 0
+min_pop = 20
+repeatable_weight_decrease = 2
+
+//unusable rulesets
+//these two don't work currently, the only fix is by manually injecting ops in and loading the shuttle in at their outpost.
+["Roundstart Clownops"]
+weight = 0
+min_pop = 30
+repeatable = 0
+
+["Midround Clownops"]
+weight = 0
+min_pop = 30
+repeatable = 0

--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -264,6 +264,14 @@ weight.4 = 2
 min_pop = 40
 repeatable = 0
 
+["Roundstart Blood Worm"]
+weight.1 = 3
+weight.2 = 4
+weight.3 = 4
+weight.4 = 5
+min_pop = 20
+repeatable = 0
+
 //light midround rulesets
 ["Midround Obsessed"]
 weight.1 = 8


### PR DESCRIPTION
Change log-
**Bluestar has a weight of 2 and 0 pop needed** from weight of 0
**Yellow star has a weight of 23 and 0 pop needed** from weight of 10 and 0 pop needed
**Orange star has a weight of 38 and 18 pop needed** from weight of 38 and 10 pop needed
**Red star has a weight of 23 and 27 pop needed** from weight of 35 and 20 pop needed
**Black orbit has a weight of 14 and 35 pop needed** from weight of 10 and  30pop needed

what does this look like for lower population rounds.
Thresholds of population are the following:
0 18- 27- 35 readied up population needed.
Bluestar happens 8%- 3.17%- 2.32%- 2% of the time.
Yellow star happens 92%- 35%- 26%- 23% of the time.
orange star happens 0- 60.3%- 44.18%- 38% of the time.
Red star happens 0- 0- 26.74- 23% of the time.
black orbit happens 0- 0- 0- 14% of the time.
Roundstart thresholds are down from 40 default on yellow/orange star to 35 pop to get the full effect at roundstart and latejoining.

There are more rulesets added to each tier, besides bluestar. Bluestar cannot be changed. These changes are tied to starting population and living population.
**(placeholder):** (current) to **(new/suggested)**

**Yellow went from** 1-1 to **2-4 roundstart**, 1-2 to **3-4 lightmid**, 0-0 to **0-1 heavy**, 0-1 to **0-2 latejoin**,
**Orange went from** 2-4 to **3-5 roundstart**, 0-2 to **2-3 lightmid**, 0-1 to **1-3 heavy**, 0-2 to **2-2 latejoin**
**Red went from** 2-4 to **3-5 roundstart**, 1-1 to **2-3 lightmid**, 1-2 to **2-3 heavy** , 0-2 to **1-2 latejoin**
**Black went from** 2-3 to **3-5 roundstart**, **1-2 no change lightmid**, **5-5 no change heavy**, **1-2 no change latejoin**

Latejoining starts 45 to 55 minutes later. What those ruleset adds, is added to other buckets instead since the timer began roundstart. This removes the option of roundstart latejoin antagonist rolling and also gives second wind to the round if all the antagonist are dead by then.

Antagonist weights.
ax-bx-cx-dx means yellow-orange-red-black
**(placeholder):** (current) to **(new/suggested)**
Roundstart- important to note, that even a yellow star could have cult, wizard, heretics, which you would have normally never saw.  

**Traitor:** 10-10-5-10 to **25-28-13-21** requires 3 population
**BB:** 10-5-3-3 to **19-15-7-4** requires 10 pop
**Changeling:** 3-5-5-10 to **7-9-9-17** requires 15 pop
**Cult:** 0-0-3-5 to **1-3-5-4** requires 30 pop
**Heretic:** 0-3-5-10 to **6-8-8-11** requires 30 pop
**Revolution:** 0-0-3-5 to **1-3-5-5** requires 30 pop
**Spies:** 10-5-3-3 to **15-11-6-12** requires 10 pop
**Malf:** 0-0-3-5 to **1-3-3-5** requires 30 pop
**Wizard:** 0-0-3-5 to **1-1-3-5** requires 35 pop
**Bloodworm:** 2-2-2-2 to **3-4-4-5** requires 20 pop
**Nations:** 0-0-0-0 to **2-0-2-0** requires 40 pop
**Total weights:** 35-30-38-63 to **82-88-68-91**

### **Midrounds:**

### Light midround bucket
ax-bx-cx-dx means yellow-orange-red-black
**(placeholder):** (current) to **(new/suggested)**

**Traitor:** 10-10-5-5 to **22-18-18-18**
**Obsessed:** 5-3-1-0 to **8-8-8-8**
**Rev ghost:** 5-3-1-0 to **5-5-2-2** 
**Paraclone:** 5-3-1-0 to **8-8-10-10** 
**light pirates:** 2-3-3-5 to **6-6-6-6** 
**Nightmare:** 3-5-5-10 to **2-2-4-6**
**Changeling:** 3-5-5-10 to 8-9-9-13
**Abductors:** 5-3-3-1 to **3-3-3-2**
**Fugitives:** 3-3-1-0 to **9-9-6-6** 
**Voidwalker:** **3-5-5-10 no change**
**Bloodworm:** 2-2-2-2 to **3-3-4-6**
**Total weights:** 46-45-34-44 to **77-76-75-87**

### Heavy midround bucket
ax-bx-cx-dx means yellow-orange-red-black
**(placeholder):** (current) to **(new/suggested)**

**Heavy pirate: 5-5-5-5 no change**
**Wizard:** 1-0-1-5 to **1-1-3-5** 
**Spiders:** 10-10-5-5 to **10-5-5-5** 
**Nukeops:** 2-1-2-5 to **1-1-5-5** 
**Blob:** 2-2-3-3 to **3-3-4-4** 
**blob infect:** 2-2-3-3 to **3-4-4-4** 
**Xeno:** 10-5-10-5 to **10-5-8-5** 
**Dragon:** 10-5-10-5 to **5-5-6-6**
**Ninja:** 10-10-5-5 to **10-10-5-5** 
**Malf:** 5-2-5-5 to **5-2-5-5** 
**Mass ling:** 0-3-4-5 to **1-5-5-6** 
**Mass traitor:** 0-3-8-10 to **8-13-13-8**
**Total weight:** 57-48-61-61 to **62-59-68-62**

Now timing of each ruleset latejoin, lightmid, heavy for when they start and then average time spent injecting and when they should all be done with. Dynamic must clear all light midrounds before injecting heavy into pool.

Latejoin timer starts 15-10-5-5 minutes into a shift. This now **starts at 55-55-45-45 minutes.**

Light midround timer starts at 25-30-25-15 minutes into a shift. This now **starts at 28-35-30-15 minutes.**
Dynamic cycles used to end this segment was between and now currently

**Yellow orbit:** 50-65-85 minutes, to **55-66.25-80 minutes** Ruleset injection 0-2 to **3-4**
**Orange orbit:** 30-36.25-45 minutes, to **45-50-55 minutes.** Ruleset injection 0-2 to **2-2**
**Red orbit:** 25-25-25 minutes, to **35-41.25-50 minutes.** Ruleset injection 1-2 to **2-3**
**Black orbit:** 15-15-15 minutes, to **25-25-25 minutes.** Ruleset injection **1-1 no change**

Heavy midround timer is 0-40-60-30 minutes into a shift This now **starts at 50-40-40-30 minutes.**
Dynamic cycles used to end this segment was between and what they are now currently to clear the stack. The middle number is the important average when this should all be used up.

**Yellow orbit:** 0-0-0 minutes to **50-65-50 minutes** Ruleset injection is 0-0 to **1-1.**
**Orange orbit:** 40-62.5-60 minutes to **40-58.75-55 minutes.** minutes Ruleset injection is 1-2 to **1-3.**
**Red orbit:** 40-62.5-60 minutes to **50-77.5-80 minutes.** minutes Ruleset injection 1-2 to **2-3.**
**Black orbit:** **70-105-110 minutes. Ruleset injection is 5-5, nothing changed.**
Important understanding, why these numbers went up. there are more rulesets that dynamic must go through and must complete every single injection. There must be 0 light round rulesets remaining to get into heavy ruleset rolls.