### PR TITLE
Manuel Dynamic 1.21: Fuck it we ball

### DIFF
--- a/manuel/dynamic.toml
+++ b/manuel/dynamic.toml
@@ -41,14 +41,14 @@ ruleset_type_settings.roundstart.full_range_pop_threshold = 21
 ruleset_type_settings.light_midround.low = 4
 ruleset_type_settings.light_midround.high = 5
 ruleset_type_settings.light_midround.half_range_pop_threshold = 18
-ruleset_type_settings.light_midround.full_range_pop_threshold = 21
+ruleset_type_settings.light_midround.full_range_pop_threshold = 26
 ruleset_type_settings.light_midround.time_threshold = 25
 ruleset_type_settings.light_midround.execution_cooldown_low = 10
 ruleset_type_settings.light_midround.execution_cooldown_high = 15
 ruleset_type_settings.heavy_midround.low = 1
 ruleset_type_settings.heavy_midround.high = 2
 ruleset_type_settings.heavy_midround.half_range_pop_threshold = 18
-ruleset_type_settings.heavy_midround.full_range_pop_threshold = 25
+ruleset_type_settings.heavy_midround.full_range_pop_threshold = 26
 ruleset_type_settings.heavy_midround.time_threshold = 50
 ruleset_type_settings.heavy_midround.execution_cooldown_low = 15
 ruleset_type_settings.heavy_midround.execution_cooldown_high = 20
@@ -185,7 +185,7 @@ weight.1 = 25
 weight.2 = 28
 weight.3 = 13
 weight.4 = 21
-min_pop = 11
+min_pop = 8
 repeatable_weight_decrease = 6
 
 ["Roundstart Spies"]
@@ -193,7 +193,7 @@ weight.1 = 15
 weight.2 = 11
 weight.3 = 6
 weight.4 = 12
-min_pop = 11
+min_pop = 8
 repeatable_weight_decrease = 4
 
 ["Roundstart Blood Brothers"]
@@ -201,7 +201,7 @@ weight.1 = 19
 weight.2 = 15
 weight.3 = 7
 weight.4 = 4
-min_pop = 11
+min_pop = 8
 repeatable_weight_decrease = 6
 
 ["Roundstart Changeling"]
@@ -275,7 +275,7 @@ weight.1 = 8
 weight.2 = 8
 weight.3 = 5
 weight.4 = 5
-min_pop = 5
+min_pop = 10
 repeatable_weight_decrease = 4
 
 ["Revenant"]
@@ -299,8 +299,8 @@ weight.1 = 17
 weight.2 = 14
 weight.3 = 13
 weight.4 = 13
-min_pop = 11
-repeatable_weight_decrease = 4
+min_pop = 8
+repeatable_weight_decrease = 5
 
 ["Midround Changeling"]
 weight.1 = 8


### PR DESCRIPTION
changelog-
Yellow star increased the living thresholds for lower chance of antagonist in a round to lower the chance to overwhelm low population. Syndie city isn't as fun. 

Round start Traitor: requires 8 population from 11 
Spies: requires 8 population from 11
BB: requires 8 population from 11
Midround Traitor: requires 8. Reduced weight 4 to 5. 
Obessed: requires 10 population from 5