### PR TITLE
13 is the number to cross over for votes.

### DIFF
--- a/map_vote.txt
+++ b/map_vote.txt
@@ -1,6 +1,6 @@
 
 ## A flat bonus to give to all maps after a map vote is concluded.
-MAP_VOTE_FLAT_BONUS 0
+MAP_VOTE_FLAT_BONUS 2
 
 ## The minimum number of tallies a map can have for purposes of map rotation.
 MAP_VOTE_MINIMUM_TALLIES 1
@@ -9,7 +9,7 @@ MAP_VOTE_MINIMUM_TALLIES 1
 MAP_VOTE_MAXIMUM_TALLIES 200
 
 ## The percentage of tallies that are carried over between rounds.
-MAP_VOTE_TALLY_CARRYOVER_PERCENTAGE 100
+MAP_VOTE_TALLY_CARRYOVER_PERCENTAGE 86
 
 ## Pop requirement to exclude recently played maps from votes.
 MAP_VOTE_MIN_POP_TO_REMEMBER_MAP 13


### PR DESCRIPTION
re-adding back in flat vote with the tally carryover

What this does is on cycle 10 of "if a map is not chosen or voted for", the static number will be artificially driven up to 12.9, which rounded up is 13, with the carryover percentage, the added flat vote stays on 12.9 unless given more numbers.
Vote value after chosen:
 0 -> 2 -> 4 → 6 -> 7 -> 8 -> 9 -> 10 -> 11 -> 12 -> 13 ->13 -> 13 -> 13.
 
 This should account for when flat vote bonus goes through dead periods of the day.