### PR TITLE
heretic non-repeatable on manuel

### DIFF
--- a/manuel/dynamic.toml
+++ b/manuel/dynamic.toml
@@ -234,7 +234,7 @@ weight.2 = 8
 weight.3 = 8
 weight.4 = 13
 min_pop = 23
-repeatable_weight_decrease = 3
+repeatable = 0
 
 ["Roundstart Wizard"]
 weight.1 = 1


### PR DESCRIPTION
prevents the scenario of upwards of 4-6 heretics on high pop, and functionally increases the probability of more varied rulesets being chosen. there is some awkwardness with RP rules and heretics. the threat of an individual heretic can range anywhere from harmless to wiping the station depending on the user at the helm. i think a functional maximum of 1-3 heretics in any round is probably fine. we ran with a max of 1 per round for some time, and i think that was before they were giga buffed.