### PR TITLE
Enable Academy gateway map

### DIFF
--- a/awaymissionconfig.txt
+++ b/awaymissionconfig.txt
@@ -14,3 +14,4 @@ _maps/RandomZLevels/research.dmm
 _maps/RandomZLevels/SnowCabin.dmm
 _maps/RandomZLevels/museum.dmm
 _maps/RandomZLevels/heretic.dmm
+_maps/RandomZLevels/Academy.dmm


### PR DESCRIPTION
fixed up in code here https://github.com/tgstation/tgstation/pull/95298
no idea who/what/when/why disabled/removed it previously, but found this https://github.com/tgstation/tgstation/pull/66161