### PR TITLE
Reduces blood brother spawns (on Terry)

### DIFF
--- a/terry/dynamic.toml
+++ b/terry/dynamic.toml
@@ -193,12 +193,12 @@ min_pop = 30
 repeatable = 0
 
 ["Roundstart Blood Brothers"]
-weight.1 = 19
-weight.2 = 15
-weight.3 = 7
-weight.4 = 4
+weight.1 = 5
+weight.2 = 4
+weight.3 = 3
+weight.4 = 2
 min_pop = 10
-repeatable_weight_decrease = 6
+repeatable = 0
 
 ["Roundstart Changeling"]
 weight.1 = 7


### PR DESCRIPTION
<img width="401" height="125" alt="image" src="https://github.com/user-attachments/assets/bc4fd4bc-d423-407a-9d07-52a2697237bf" />

I can't take it anymore

All of this is based on my, and others, experience with blood brother on Terry. I have no clue about how they play on Manuel

### Blood Brother spam
Blood brothers are more common than traitors. Yellow orbit traitors have a weight of 25, BB's a weight of 19, but BB's can convert 2 to 3 other players, guaranteeing you'll see a lot of them in almost every round. Most of our rounds threat being based on blood brothers only aggravates the problems it has as an antag. 

It just means there are too many antags, and all of them are allowed to do absolutely everything. 

### The Metafriend problem

In the first version, you got assigned a random blood brother (https://github.com/tgstation/tgstation/pull/30344). This sucked because you got stuck with random people who just kinda fucked off. 

In the second version (https://github.com/tgstation/tgstation/pull/79971), you can select your own blood brother. 
While you had less of a problem with blood brothers fucking off, you now have the metafriend problem. Robust players and/or attention seekers are a LOT more likely to get converted, and you very often get the same pairs of players dominating the server. 

### The no gear problem
This is a weird one but a real one. People use what they get. Give someone a hammer, and everything becomes a nail etc etc.
It's a legit way in game-design that I often employ to influence players to interact with a feature in a certain way. 

Traitors and changelings have abilities and gears that do things besides just killing, but blood brothers don't get any. Sadly I don't see people use the hammer of their jobs very often, and instead opting to try to cause the largest impacts possible. Usually this manifests as trying to speedrun rounds through delams, floodings, murderbones etc. Every antag does this to some degree, but I see blood brothers do it A LOT more than others. 

I am not entirely sure why this happens the way it does? I have some quessed but they're all pretty pessimistic (take with a gran of salt):
- The same burnouts consistently get blood brothers (I know a lot of people that like to actually play their jobs that actively dislike blood brothers, and so don't role for it)
- It's actually all they can think of if there is no gear or abilities pushing them in different directions
- No gear is seen as a challenge so they always try to get the highest impact possible

Another problem this causes is that you have to escalate against blood brothers as security. There's no valid gear, making them very difficult to distinguish from non-antag griefers/tiders. They essentially act as mini-revolutions, but you can't kill the revheads or deconvert them, especially in the maddening quantity that they spawn (and convert others). Not to mention that they lower the quality of non-antags as well, degrading the overal experience long term

(See also this policy discussion about speedrunning rounds, which describes at as done almost exclusively by blood brothers: https://forums.tgstation13.org/viewtopic.php?t=38983)

This PR makes the blood brother ruleset non-repeatable and about quarters their weight (on Terry). All the above problems are so incredibly toxic to the game because of their sheer quantity. If they only happen sometimes, and there can only be a few blood brothers, these issues are a lot less pronounced

